### PR TITLE
Add Content OS CLI, core workflow, adapters, and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Optional OpenAI-compatible LLM endpoint (OpenAI, LM Studio, Ollama proxy, etc.)
+CONTENT_OS_LLM_BASE_URL=http://localhost:1234/v1
+CONTENT_OS_LLM_API_KEY=lm-studio
+CONTENT_OS_LLM_MODEL=local-model
+CONTENT_OS_LLM_TEMPERATURE=0.4
+CONTENT_OS_LLM_MAX_TOKENS=1200

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+*.egg-info/
+dist/
+build/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# Content OS
+
+Content OS is a local-first, file-based workflow for capturing ideas, routing them, building compact writer briefs, drafting in a creator voice, verifying quality, requiring human approval, preparing scheduler handoff, and learning from feedback.
+
+It is intentionally **approval-gated**. The CLI does not scrape social platforms, does not bypass platform rules, and does not auto-publish. External inputs should come from user-provided files, approved APIs, exports, or manual notes. Postiz support is an export/handoff layer only unless an approved draft integration is explicitly added later.
+
+## Folder structure
+
+`content-os init` creates:
+
+```text
+content-os/
+  strategy/                 positioning, audience, pillars, source watchlist
+  voice/                    voice profile and master avoid-slop rules
+  stores/                   inbox, workboard, ideas, hooks, proof, feedback, winners, losers
+  runs/active/              one active content object per run folder
+  runs/archive/             archived or example runs
+  modules/writer/           writer skill, references, templates
+  workflows/                lifecycle docs and checklists
+  config.yaml               score and feedback thresholds
+```
+
+Each run folder contains `content-object.yaml`, `idea.md`, `brief.md`, `draft-package.md`, `verification.md`, `review.md`, `scheduler-handoff.md`, and `feedback.md` as they are created.
+
+See [docs/architecture.md](docs/architecture.md) for the implementation diagram, lifecycle gate diagram, module responsibilities, and autoingest integration flow.
+
+## Lifecycle
+
+`captured → idea_review → brief_ready → drafting → verification → human_review → approved → scheduler_ready → scheduled → published → feedback_24h → feedback_72h → learned → archived`
+
+Backward movement requires force in commands that expose it and is recorded in review notes when relevant.
+
+## Routes
+
+- `ORIGINAL`: user notes, proof, strategy, voice, personal knowledge, and prior content.
+- `REPURPOSE`: user-owned content converted into a new format.
+- `REWRITE`: user-supplied external signal rewritten through the creator viewpoint; attribution metadata must be preserved.
+- `RESEARCH_IDEATE`: topic exploration that feeds candidate ideas instead of final posts.
+
+## CLI usage
+
+```bash
+content-os init
+content-os capture --title "Raw idea" --text "A note from today" --route auto
+content-os new-run --title "Bookmarkable content systems" --route ORIGINAL --format x_thread
+content-os brief 2026-05-bookmarkable-content-systems
+content-os draft 2026-05-bookmarkable-content-systems
+# Edit draft-package.md to replace TODOs with proof-backed copy before verifying/approving.
+content-os verify 2026-05-bookmarkable-content-systems
+content-os approve 2026-05-bookmarkable-content-systems
+content-os scheduler-handoff 2026-05-bookmarkable-content-systems --platform x
+content-os postiz-export 2026-05-bookmarkable-content-systems --out ./postiz_payload.json
+content-os feedback 2026-05-bookmarkable-content-systems --views 10000 --bookmarks 600 --likes 300 --replies 40 --reposts 80
+```
+
+Use `content-os capture --no-run` when you only want to append to `stores/inbox.md`. Use `content-os status` for active work and `content-os doctor` to validate structure, config, environment, and YAML/Markdown health.
+
+## LLM configuration
+
+The system works without an LLM; `draft` creates a structured placeholder with TODOs. To use an OpenAI-compatible chat endpoint, set:
+
+```bash
+CONTENT_OS_LLM_BASE_URL=https://api.openai.com/v1
+CONTENT_OS_LLM_API_KEY=...
+CONTENT_OS_LLM_MODEL=...
+CONTENT_OS_LLM_TEMPERATURE=0.4
+CONTENT_OS_LLM_MAX_TOKENS=1200
+```
+
+### LM Studio example
+
+```bash
+export CONTENT_OS_LLM_BASE_URL=http://localhost:1234/v1
+export CONTENT_OS_LLM_API_KEY=lm-studio
+export CONTENT_OS_LLM_MODEL=local-model
+content-os draft <RUN_ID>
+```
+
+## Postiz handoff flow
+
+After verification passes and a human approves, `scheduler-handoff` creates approved copy, platform notes, attribution, UTM fields, and a Postiz-ready JSON block. `postiz-export` writes a JSON payload with `requires_manual_review=true`. This project does not auto-publish.
+
+## Reviewing voice over time
+
+Put proven examples in `stores/proof/` and strong openings in `stores/hooks/`. Feedback stores winner/loser lessons and proposes changes in `feedback.md`; it never overwrites `voice/master-avoid-slop.md` automatically.
+
+## Privacy and compliance
+
+Do not scrape X/Twitter or other platforms. Use manual inputs, user-owned content, exports, and approved APIs. Always review generated drafts and scheduler payloads before publishing.
+
+## Autoingest repo integration
+
+This repository already contains local media/transcript/metadata tooling. Content OS can now adapt those approved local outputs into proof and run folders without scraping anything:
+
+```bash
+content-os scan-inputs ./transcripts --out ./content-os/stores/proof/input-scan.md
+content-os ingest-source ./transcripts/interview_segments.json --title "Lessons from the ingest pipeline" --route REPURPOSE --format linkedin
+content-os ingest-source ./Dashcam_Research.pdf --title "Dashcam research notes" --no-run
+```
+
+Supported local input families include Markdown/text notes, transcript exports (`.txt`, `.srt`, `.vtt`, Whisper-style JSON segments), CSV/JSON metadata exports, PDFs when `pypdf` is installed, and binary media manifests. Binary media is never transcribed automatically by Content OS; use this repo's approved local transcription/export scripts first, then ingest the resulting files.
+
+Dynamic source rules live in `content-os/integrations/source-adapters.json`. Add a rule there to support a new extension or JSON shape without changing Python code, then run `content-os list-adapters` to confirm the rule is active. `content-os doctor` validates the adapter registry and reports malformed JSON, invalid extensions, invalid routes, and invalid formats. Ingested sources are tracked by SHA-256 in `stores/proof/source-manifest.json` so proof can be traced back to local inputs.
+
+`RESEARCH_IDEATE` routes write candidate material into `stores/ideas/` so research scans do not become publishable drafts without a separate human-reviewed run.

--- a/content_os/__init__.py
+++ b/content_os/__init__.py
@@ -1,0 +1,3 @@
+"""Local-first Content OS."""
+
+__version__ = "0.1.0"

--- a/content_os/__main__.py
+++ b/content_os/__main__.py
@@ -1,0 +1,5 @@
+"""Run the Content OS CLI with ``python -m content_os``."""
+
+from .cli import main
+
+raise SystemExit(main())

--- a/content_os/adapters.py
+++ b/content_os/adapters.py
@@ -1,0 +1,512 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import re
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+MAX_TEXT_BYTES = 250_000
+TEXT_EXTENSIONS = {".txt", ".md", ".markdown", ".log", ".srt", ".vtt"}
+MEDIA_EXTENSIONS = {
+    ".mp3",
+    ".wav",
+    ".m4a",
+    ".flac",
+    ".mp4",
+    ".mov",
+    ".mkv",
+    ".avi",
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".webp",
+}
+IGNORED_PARTS = {
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    "build",
+    "dist",
+    ".venv",
+    "venv",
+}
+
+
+@dataclass
+class SourceDocument:
+    path: Path
+    title: str
+    source_type: str
+    text: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    suggested_route: str = "REPURPOSE"
+    suggested_format: str = "custom"
+    warnings: list[str] = field(default_factory=list)
+    adapter: str = "unknown"
+    sha256: str = ""
+
+    @property
+    def source_id(self) -> str:
+        digest = self.sha256[:12] if self.sha256 else "unhashed"
+        return f"{self.source_type}:{digest}"
+
+    def to_markdown(self) -> str:
+        warnings = "\n".join(f"- {w}" for w in self.warnings) or "- None"
+        metadata = json.dumps(self.metadata, indent=2, sort_keys=True)
+        return f"""# Source: {self.title}
+
+- source_id: `{self.source_id}`
+- path: `{self.path}`
+- type: {self.source_type}
+- adapter: {self.adapter}
+- sha256: `{self.sha256 or 'not_computed'}`
+- suggested_route: {self.suggested_route}
+- suggested_format: {self.suggested_format}
+
+## warnings
+{warnings}
+
+## metadata
+```json
+{metadata}
+```
+
+## extracted text
+{self.text}
+"""
+
+
+@dataclass
+class AdapterRule:
+    name: str
+    extensions: set[str]
+    source_type: str
+    text_keys: list[str] = field(default_factory=list)
+    title_keys: list[str] = field(default_factory=list)
+    route: str = "REPURPOSE"
+    format: str = "custom"
+    treat_as_text: bool = True
+
+
+class SourceAdapter(Protocol):
+    name: str
+
+    def can_handle(self, path: Path) -> bool: ...
+
+    def extract(self, path: Path) -> SourceDocument: ...
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_limited(path: Path, limit: int = MAX_TEXT_BYTES) -> tuple[str, bool]:
+    data = path.read_bytes()[: limit + 1]
+    truncated = len(data) > limit
+    if truncated:
+        data = data[:limit]
+    text = data.decode("utf-8", errors="replace")
+    return text, truncated
+
+
+def title_from_path(path: Path) -> str:
+    return re.sub(r"[_\-]+", " ", path.stem).strip().title() or path.name
+
+
+def strip_subtitle_noise(text: str) -> str:
+    lines = []
+    for line in text.splitlines():
+        clean = line.strip()
+        if not clean or clean.isdigit() or "-->" in clean or clean.upper() == "WEBVTT":
+            continue
+        lines.append(clean)
+    return "\n".join(lines)
+
+
+def _segment_text(data: Any) -> str:
+    if isinstance(data, dict):
+        if isinstance(data.get("segments"), list):
+            parts = []
+            for segment in data["segments"]:
+                if isinstance(segment, dict) and segment.get("text"):
+                    start = segment.get("start")
+                    prefix = f"[{start}] " if start is not None else ""
+                    parts.append(f"{prefix}{segment['text']}")
+            return "\n".join(parts)
+        for key in ["transcript", "text", "summary", "content", "description"]:
+            if isinstance(data.get(key), str):
+                return data[key]
+    if isinstance(data, list):
+        parts = []
+        for item in data:
+            if isinstance(item, dict) and item.get("text"):
+                parts.append(str(item["text"]))
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    return ""
+
+
+def value_from_keys(data: Any, keys: list[str]) -> str:
+    if not isinstance(data, dict):
+        return ""
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
+class RuleBasedAdapter:
+    def __init__(self, rule: AdapterRule):
+        self.rule = rule
+        self.name = f"rule:{rule.name}"
+
+    def can_handle(self, path: Path) -> bool:
+        return path.suffix.lower() in self.rule.extensions
+
+    def extract(self, path: Path) -> SourceDocument:
+        raw, truncated = read_limited(path)
+        warnings = ["File was truncated for local ingest."] if truncated else []
+        text = raw
+        title = title_from_path(path)
+        metadata: dict[str, Any] = {
+            "extension": path.suffix.lower(),
+            "bytes": path.stat().st_size,
+            "rule": self.rule.name,
+        }
+        if self.rule.text_keys and (
+            path.suffix.lower() == ".jsonl" or raw.lstrip().startswith(("{", "["))
+        ):
+            if path.suffix.lower() == ".jsonl":
+                rows = [json.loads(line) for line in raw.splitlines() if line.strip()]
+                text = "\n".join(
+                    value_from_keys(row, self.rule.text_keys)
+                    for row in rows
+                    if value_from_keys(row, self.rule.text_keys)
+                )
+                metadata["records"] = len(rows)
+                if rows:
+                    title = value_from_keys(rows[0], self.rule.title_keys) or title
+            else:
+                data = json.loads(raw)
+                text = value_from_keys(data, self.rule.text_keys) or _segment_text(data)
+                title = value_from_keys(data, self.rule.title_keys) or title
+                metadata["json_shape"] = "object" if isinstance(data, dict) else "list"
+            if not text:
+                warnings.append(
+                    "Rule did not find configured text keys; preserved raw text excerpt."
+                )
+                text = raw[:MAX_TEXT_BYTES]
+        return SourceDocument(
+            path=path,
+            title=title,
+            source_type=self.rule.source_type,
+            text=text,
+            metadata=metadata,
+            suggested_route=self.rule.route,
+            suggested_format=self.rule.format,
+            warnings=warnings,
+            adapter=self.name,
+            sha256=file_sha256(path),
+        )
+
+
+class JsonAdapter:
+    name = "json"
+
+    def can_handle(self, path: Path) -> bool:
+        return path.suffix.lower() in {".json", ".jsonl"}
+
+    def extract(self, path: Path) -> SourceDocument:
+        raw, truncated = read_limited(path)
+        warnings = ["File was truncated for local ingest."] if truncated else []
+        if path.suffix.lower() == ".jsonl":
+            rows = [json.loads(line) for line in raw.splitlines() if line.strip()]
+            text = _segment_text(rows)
+            metadata: dict[str, Any] = {"records": len(rows)}
+        else:
+            data = json.loads(raw)
+            text = _segment_text(data)
+            metadata = (
+                data
+                if isinstance(data, dict)
+                else {"records": len(data) if isinstance(data, list) else 1}
+            )
+        source_type = (
+            "transcript_json" if "segment" in raw[:2000].lower() else "metadata_json"
+        )
+        if not text:
+            text = json.dumps(metadata, indent=2, sort_keys=True)[:MAX_TEXT_BYTES]
+            warnings.append(
+                "No transcript-like text field found; preserved metadata excerpt instead."
+            )
+        return SourceDocument(
+            path=path,
+            title=str(metadata.get("title") or title_from_path(path)),
+            source_type=source_type,
+            text=text,
+            metadata=(
+                {k: v for k, v in metadata.items() if k != "segments"}
+                if isinstance(metadata, dict)
+                else metadata
+            ),
+            suggested_route="REPURPOSE",
+            warnings=warnings,
+            adapter=self.name,
+            sha256=file_sha256(path),
+        )
+
+
+class CsvAdapter:
+    name = "csv"
+
+    def can_handle(self, path: Path) -> bool:
+        return path.suffix.lower() == ".csv"
+
+    def extract(self, path: Path) -> SourceDocument:
+        raw, truncated = read_limited(path)
+        reader = csv.DictReader(raw.splitlines())
+        rows = list(reader)
+        sample = rows[:10]
+        columns = reader.fieldnames or []
+        text_fields = [
+            c
+            for c in columns
+            if c
+            and c.lower()
+            in {"text", "transcript", "summary", "content", "note", "notes"}
+        ]
+        if text_fields:
+            extracted = "\n".join(
+                str(row.get(text_fields[0], ""))
+                for row in rows
+                if row.get(text_fields[0])
+            )
+        else:
+            extracted = "\n".join(json.dumps(row, sort_keys=True) for row in sample)
+        warnings = ["File was truncated for local ingest."] if truncated else []
+        return SourceDocument(
+            path=path,
+            title=title_from_path(path),
+            source_type="tabular_export",
+            text=extracted or "No rows found.",
+            metadata={
+                "columns": columns,
+                "rows_read": len(rows),
+                "sample_rows": sample,
+            },
+            warnings=warnings,
+            adapter=self.name,
+            sha256=file_sha256(path),
+        )
+
+
+class TextAdapter:
+    name = "text"
+
+    def can_handle(self, path: Path) -> bool:
+        return path.suffix.lower() in TEXT_EXTENSIONS
+
+    def extract(self, path: Path) -> SourceDocument:
+        raw, truncated = read_limited(path)
+        ext = path.suffix.lower()
+        text = strip_subtitle_noise(raw) if ext in {".srt", ".vtt"} else raw
+        lowered = path.name.lower() + "\n" + text[:1000].lower()
+        if "summary" in lowered:
+            source_type = "summary"
+        elif "transcript" in lowered or ext in {".srt", ".vtt"}:
+            source_type = "transcript"
+        elif ext in {".md", ".markdown"}:
+            source_type = "markdown_note"
+        else:
+            source_type = "text_note"
+        warnings = ["File was truncated for local ingest."] if truncated else []
+        return SourceDocument(
+            path=path,
+            title=title_from_path(path),
+            source_type=source_type,
+            text=text,
+            metadata={"extension": ext, "bytes": path.stat().st_size},
+            warnings=warnings,
+            adapter=self.name,
+            sha256=file_sha256(path),
+        )
+
+
+class PdfAdapter:
+    name = "pdf"
+
+    def can_handle(self, path: Path) -> bool:
+        return path.suffix.lower() == ".pdf"
+
+    def extract(self, path: Path) -> SourceDocument:
+        warnings = []
+        text = ""
+        if importlib.util.find_spec("pypdf"):
+            import pypdf  # type: ignore
+
+            reader = pypdf.PdfReader(str(path))
+            text = "\n".join(page.extract_text() or "" for page in reader.pages[:20])
+        else:
+            warnings.append(
+                "pypdf is not installed; captured PDF as a file manifest only."
+            )
+        return SourceDocument(
+            path=path,
+            title=title_from_path(path),
+            source_type="pdf_document",
+            text=text
+            or f"PDF source available at {path}. Extract text manually or install pypdf for local extraction.",
+            metadata={"extension": ".pdf", "bytes": path.stat().st_size},
+            warnings=warnings,
+            adapter=self.name,
+            sha256=file_sha256(path),
+        )
+
+
+class MediaManifestAdapter:
+    name = "media_manifest"
+
+    def can_handle(self, path: Path) -> bool:
+        return path.suffix.lower() in MEDIA_EXTENSIONS
+
+    def extract(self, path: Path) -> SourceDocument:
+        return SourceDocument(
+            path=path,
+            title=title_from_path(path),
+            source_type="media_asset",
+            text=(
+                f"Media asset captured as a manifest only: {path.name}. "
+                "Use approved local transcription, metadata export, screenshots, or notes as proof before drafting."
+            ),
+            metadata={"extension": path.suffix.lower(), "bytes": path.stat().st_size},
+            suggested_route="REPURPOSE",
+            warnings=["Binary media is not transcribed automatically by Content OS."],
+            adapter=self.name,
+            sha256=file_sha256(path),
+        )
+
+
+ADAPTERS: list[SourceAdapter] = [
+    JsonAdapter(),
+    CsvAdapter(),
+    TextAdapter(),
+    PdfAdapter(),
+    MediaManifestAdapter(),
+]
+
+
+def adapters_for_rules(rules: list[AdapterRule] | None = None) -> list[SourceAdapter]:
+    rule_adapters = [RuleBasedAdapter(rule) for rule in (rules or [])]
+    return rule_adapters + ADAPTERS
+
+
+def detect_adapter(
+    path: Path, rules: list[AdapterRule] | None = None
+) -> SourceAdapter | None:
+    for adapter in adapters_for_rules(rules):
+        if adapter.can_handle(path):
+            return adapter
+    return None
+
+
+def extract_source(
+    path: Path, rules: list[AdapterRule] | None = None
+) -> SourceDocument:
+    adapter = detect_adapter(path, rules=rules)
+    if adapter:
+        return adapter.extract(path)
+    raw, truncated = read_limited(path)
+    if "\x00" in raw[:1000]:
+        return SourceDocument(
+            path=path,
+            title=title_from_path(path),
+            source_type="unknown_binary",
+            text=f"Unsupported binary source captured as manifest only: {path.name}",
+            metadata={"extension": path.suffix.lower(), "bytes": path.stat().st_size},
+            warnings=[
+                "Unsupported binary format; provide a manual export or approved API output."
+            ],
+            adapter="unknown_binary",
+            sha256=file_sha256(path),
+        )
+    return SourceDocument(
+        path=path,
+        title=title_from_path(path),
+        source_type="unknown_text",
+        text=raw,
+        metadata={"extension": path.suffix.lower(), "bytes": path.stat().st_size},
+        warnings=["Unknown extension treated as text."]
+        + (["File was truncated for local ingest."] if truncated else []),
+        adapter="unknown_text",
+        sha256=file_sha256(path),
+    )
+
+
+def iter_supported_files(base: Path, limit: int = 100) -> list[Path]:
+    if base.is_file():
+        return [base]
+    files: list[Path] = []
+    for path in sorted(base.rglob("*")):
+        if len(files) >= limit:
+            break
+        if not path.is_file() or any(part in IGNORED_PARTS for part in path.parts):
+            continue
+        files.append(path)
+    return files
+
+
+def scan_path(
+    base: Path, limit: int = 100, rules: list[AdapterRule] | None = None
+) -> list[SourceDocument]:
+    docs: list[SourceDocument] = []
+    for path in iter_supported_files(base, limit=limit):
+        try:
+            docs.append(extract_source(path, rules=rules))
+        except (
+            OSError,
+            UnicodeError,
+            ValueError,
+            json.JSONDecodeError,
+            csv.Error,
+        ) as exc:
+            docs.append(
+                SourceDocument(
+                    path=path,
+                    title=title_from_path(path),
+                    source_type="unreadable",
+                    text="",
+                    metadata={"extension": path.suffix.lower()},
+                    warnings=[f"Could not read source: {exc}"],
+                    adapter="scan_error",
+                )
+            )
+    return docs
+
+
+def scan_report(base: Path, docs: list[SourceDocument]) -> str:
+    rows = "\n".join(
+        f"| `{doc.path}` | `{doc.source_id}` | {doc.adapter} | {doc.source_type} | {doc.suggested_route} | {len(doc.text)} | {', '.join(doc.warnings) or 'None'} |"
+        for doc in docs
+    )
+    return f"""# Input Scan Report
+
+Scanned: `{base}`
+
+| Path | Source ID | Adapter | Detected type | Suggested route | Extracted chars | Warnings |
+|---|---|---|---|---|---:|---|
+{rows}
+
+No external platforms were scraped. Files were read from local/user-provided inputs only.
+"""

--- a/content_os/cli.py
+++ b/content_os/cli.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import core
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="content-os", description="Local-first approval-gated Content OS"
+    )
+    p.add_argument(
+        "--root",
+        default=None,
+        help="Content OS root (default: ./content-os or current Content OS directory)",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+    i = sub.add_parser("init")
+    i.add_argument("--root", default=None)
+    i.add_argument("--force", action="store_true")
+    c = sub.add_parser("capture")
+    c.add_argument("--title", required=True)
+    c.add_argument("--text", required=True)
+    c.add_argument("--source")
+    c.add_argument(
+        "--route",
+        default="auto",
+        choices=["auto", "ORIGINAL", "REPURPOSE", "REWRITE", "RESEARCH_IDEATE"],
+    )
+    c.add_argument(
+        "--no-run",
+        action="store_true",
+        help="Only append to inbox.md; do not create a run folder.",
+    )
+    n = sub.add_parser("new-run")
+    n.add_argument("--title", required=True)
+    n.add_argument(
+        "--route",
+        default="auto",
+        choices=["auto", "ORIGINAL", "REPURPOSE", "REWRITE", "RESEARCH_IDEATE"],
+    )
+    n.add_argument(
+        "--format",
+        default="x_post",
+        choices=["x_post", "x_thread", "linkedin", "blog", "newsletter", "custom"],
+    )
+    for name in ["route", "brief", "draft", "verify", "archive"]:
+        sp = sub.add_parser(name)
+        sp.add_argument("run_id")
+        if name == "archive":
+            sp.add_argument("--force", action="store_true")
+    a = sub.add_parser("approve")
+    a.add_argument("run_id")
+    a.add_argument("--force", action="store_true")
+    a.add_argument("--reason", default="")
+    sh = sub.add_parser("scheduler-handoff")
+    sh.add_argument("run_id")
+    sh.add_argument(
+        "--platform",
+        default="custom",
+        choices=["x", "linkedin", "threads", "blog", "newsletter", "custom"],
+    )
+    pe = sub.add_parser("postiz-export")
+    pe.add_argument("run_id")
+    pe.add_argument("--out", required=True)
+    pe.add_argument(
+        "--send-to-postiz",
+        action="store_true",
+        help="Reserved for explicit draft creation; auto-publish is never performed.",
+    )
+    f = sub.add_parser("feedback")
+    f.add_argument("run_id")
+    for x in ["views", "bookmarks", "likes", "replies", "reposts"]:
+        f.add_argument(f"--{x}", required=True, type=int)
+    f.add_argument("--notes", default="")
+    scan = sub.add_parser("scan-inputs")
+    scan.add_argument("path")
+    scan.add_argument("--out")
+    scan.add_argument("--limit", type=int)
+    ingest = sub.add_parser("ingest-source")
+    ingest.add_argument("path")
+    ingest.add_argument("--title")
+    ingest.add_argument(
+        "--route",
+        default="auto",
+        choices=["auto", "ORIGINAL", "REPURPOSE", "REWRITE", "RESEARCH_IDEATE"],
+    )
+    ingest.add_argument(
+        "--format",
+        default="custom",
+        choices=["x_post", "x_thread", "linkedin", "blog", "newsletter", "custom"],
+    )
+    ingest.add_argument(
+        "--no-run",
+        action="store_true",
+        help="Only write the extracted source into stores/proof/.",
+    )
+    ingest.add_argument(
+        "--no-proof",
+        action="store_true",
+        help="Create the run without writing a stores/proof entry.",
+    )
+    sub.add_parser("list-adapters")
+    sub.add_parser("status")
+    sub.add_parser("doctor")
+    return p
+
+
+def print_table(rows, headers):
+    widths = [len(h) for h in headers]
+    data = [
+        [str(getattr(r, h.lower().replace(" ", "_"), "")) for h in headers]
+        for r in rows
+    ]
+    for row in data:
+        for i, v in enumerate(row):
+            widths[i] = max(widths[i], len(v))
+    print(" | ".join(h.ljust(widths[i]) for i, h in enumerate(headers)))
+    print("-+-".join("-" * w for w in widths))
+    for row in data:
+        print(" | ".join(row[i].ljust(widths[i]) for i in range(len(headers))))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    root = core.resolve_root(getattr(args, "root", None))
+    try:
+        if args.cmd == "init":
+            root = core.resolve_root(args.root)
+            made = core.init(root, args.force)
+            print(f"Initialized Content OS at {root} ({len(made)} files written)")
+        elif args.cmd == "capture":
+            path = core.capture(
+                root,
+                args.title,
+                args.text,
+                args.source,
+                args.route,
+                create_run_folder=not args.no_run,
+            )
+            print(path.name if path else "captured_to_inbox")
+        elif args.cmd == "new-run":
+            path = core.create_run(root, args.title, args.route, args.format)
+            print(path.name)
+        elif args.cmd == "route":
+            print(core.route_run(root, args.run_id))
+        elif args.cmd == "brief":
+            print(core.make_brief(root, args.run_id))
+        elif args.cmd == "draft":
+            print(core.draft(root, args.run_id))
+        elif args.cmd == "verify":
+            print(core.verify(root, args.run_id))
+        elif args.cmd == "approve":
+            core.approve(root, args.run_id, args.force, args.reason)
+            print("approved")
+        elif args.cmd == "scheduler-handoff":
+            print(core.scheduler_handoff(root, args.run_id, args.platform))
+        elif args.cmd == "postiz-export":
+            if args.send_to_postiz:
+                print(
+                    "--send-to-postiz acknowledged: this implementation exports only; no auto-publish or API send is performed."
+                )
+            core.postiz_export(root, args.run_id, Path(args.out))
+            print(args.out)
+        elif args.cmd == "feedback":
+            print(
+                core.feedback(
+                    root,
+                    args.run_id,
+                    args.views,
+                    args.bookmarks,
+                    args.likes,
+                    args.replies,
+                    args.reposts,
+                    args.notes,
+                )
+            )
+        elif args.cmd == "archive":
+            print(core.archive(root, args.run_id, args.force))
+        elif args.cmd == "scan-inputs":
+            docs, report_path = core.scan_inputs(
+                root, Path(args.path), Path(args.out) if args.out else None, args.limit
+            )
+            if report_path:
+                print(report_path)
+            else:
+                for doc in docs:
+                    print(
+                        f"{doc.path}	{doc.source_type}	{doc.suggested_route}	{len(doc.text)} chars"
+                    )
+        elif args.cmd == "ingest-source":
+            run_path, proof_path, source = core.import_source(
+                root,
+                Path(args.path),
+                title=args.title,
+                route=args.route,
+                fmt=args.format,
+                as_proof=not args.no_proof,
+                create_run_folder=not args.no_run,
+            )
+            print(f"source_type={source.source_type}")
+            if proof_path:
+                print(f"proof={proof_path}")
+            if run_path:
+                print(f"run={run_path.name}")
+        elif args.cmd == "list-adapters":
+            for item in core.adapter_inventory(root):
+                print(
+                    f"{item['kind']}\t{item['name']}\t{','.join(item.get('extensions', []))}"
+                )
+        elif args.cmd == "status":
+            print_table(
+                core.status(root),
+                ["id", "title", "route", "state", "score", "next_action"],
+            )
+        elif args.cmd == "doctor":
+            issues = core.doctor(root)
+            if issues:
+                print("Doctor found issues:")
+                [print(f"- {i}") for i in issues]
+                return (
+                    1
+                    if any(not i.startswith("LLM not configured") for i in issues)
+                    else 0
+                )
+            print("Doctor passed.")
+        return 0
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/content_os/core.py
+++ b/content_os/core.py
@@ -1,0 +1,981 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .adapters import (
+    AdapterRule,
+    SourceDocument,
+    extract_source,
+    scan_path,
+    scan_report,
+)
+from .io import append, atomic_write, dump_yaml, load_yaml, read_text, write_if_missing
+from .models import ContentObject, State, now_iso
+
+DEFAULT_SCORE_THRESHOLD = 8
+WIN_BOOKMARK_RATE = 0.05
+LOSE_BOOKMARK_RATE = 0.01
+VALID_ROUTES = {"auto", "ORIGINAL", "REPURPOSE", "REWRITE", "RESEARCH_IDEATE"}
+VALID_FORMATS = {"x_post", "x_thread", "linkedin", "blog", "newsletter", "custom"}
+
+STRUCTURE_DIRS = [
+    "strategy",
+    "voice",
+    "stores/ideas",
+    "stores/hooks",
+    "stores/proof",
+    "stores/feedback",
+    "stores/winners",
+    "stores/losers",
+    "runs/active",
+    "runs/archive",
+    "modules/writer/references",
+    "modules/writer/templates",
+    "workflows",
+    "integrations",
+]
+
+TEMPLATES: dict[str, str] = {
+    "strategy/positioning.md": "# Positioning\n\nWho you help, what change you create, and why your viewpoint is credible.\n",
+    "strategy/audience.md": "# Audience\n\n## Primary reader\n- Role:\n- Pain:\n- Job-to-be-done:\n- What they save/bookmark:\n",
+    "strategy/pillars.md": "# Content Pillars\n\n1. Systems\n2. Proof and build notes\n3. Opinionated lessons\n",
+    "strategy/source-watchlist.md": "# Source Watchlist\n\nUser-approved sources, APIs, exports, or manual inputs only. Do not scrape platforms.\n",
+    "voice/voice-profile.md": "# Voice Profile\n\n## Voice anchors\n- Clear, specific, and useful.\n- Short sentences with concrete nouns.\n- Shows the work; does not posture.\n",
+    "voice/master-avoid-slop.md": '# Master Avoid-Slop Rules\n\nFlag or remove these patterns unless intentionally justified:\n\n- promotional language: "groundbreaking", "game-changing"\n- significance inflation: "pivotal moment", "testament to"\n- vague attribution: "experts believe", "studies show"\n- false agency: "the system compounds", "the data tells us"\n- rhetorical setups: "the question is whether"\n- staccato cliché: "No X. No Y. No Z."\n- em dash overuse\n- filler adverbs: "actually", "literally", "quietly"\n- generic AI phrasing\n- unsupported superlatives\n',
+    "stores/inbox.md": "# Inbox\n\nCaptured ideas and raw inputs.\n",
+    "stores/workboard.md": "# Workboard\n\nUse `content-os status` for generated active run state.\n",
+    "modules/writer/SKILL.md": "# Writer Module\n\nUse compact writer packets. Do not invent proof, facts, clients, screenshots, metrics, or attribution. Preserve route constraints and human approval gates.\n",
+    "workflows/idea-to-published-post.md": "# Idea to Published Post\n\nCapture → route → brief → draft → verify → human review → approve → scheduler handoff → manual scheduling/export → feedback → learn.\n",
+    "workflows/verifier-checklist.md": "# Verifier Checklist\n\nScore bookmarkability, run avoid-slop checks, require human review, and never approve failed verification without an explicit force reason.\n",
+    "workflows/scheduler-handoff.md": "# Scheduler Handoff\n\nExport only after approval. Postiz payloads are handoff/draft data and require manual review. No auto-publishing.\n",
+    "workflows/feedback-loop.md": "# Feedback Loop\n\nRecord views, bookmarks, likes, replies, reposts, and notes. Propose voice/hook changes; never overwrite voice rules automatically.\n",
+    "integrations/autoingest.md": "# Autoingest Integration\n\nUse this repo's local transcripts, summaries, metadata exports, dashcam/audio artifacts, and analysis notes as user-owned inputs. Content OS never scrapes platforms and never transcribes binary media automatically; point it at approved local outputs with `scan-inputs` and `ingest-source`.\n",
+    "integrations/source-adapters.json": '[\n  {\n    "name": "autoingest-cypher-note",\n    "extensions": [".cy"],\n    "source_type": "graph_query_note",\n    "route": "RESEARCH_IDEATE",\n    "format": "custom",\n    "treat_as_text": true\n  },\n  {\n    "name": "custom-json-note-example",\n    "extensions": [".notejson"],\n    "source_type": "custom_json_note",\n    "text_keys": ["text", "body", "summary"],\n    "title_keys": ["title", "name"],\n    "route": "REPURPOSE",\n    "format": "custom"\n  }\n]\n',
+    "config.yaml": "score_threshold: 8\nwinning_bookmark_rate: 0.05\nlosing_bookmark_rate: 0.01\ndefault_publish_window: 'Manual choice required'\ninput_ingest:\n  max_scan_files: 100\n  preferred_proof_store: stores/proof\n  autoingest_patterns:\n    transcripts: ['**/*transcript*.txt', '**/*transcription*.json', '**/*.srt', '**/*.vtt']\n    summaries: ['**/*summar*.md', '**/*summar*.txt']\n    metadata: ['**/*metadata*.json', '**/*metadata*.csv']\n",
+}
+
+SCORE_ITEMS = [
+    "Saves the reader future work",
+    "Contains concrete proof",
+    "Provides reusable takeaway: template, checklist, framework, workflow, or mental model",
+    "Has a specific reader and job-to-be-done",
+    "Can be applied without the author present",
+    "Has a strong screenshot, visual, example, or artifact opportunity",
+]
+
+BANNED_PATTERNS = [
+    r"groundbreaking",
+    r"game-changing",
+    r"pivotal moment",
+    r"testament to",
+    r"experts believe",
+    r"studies show",
+    r"the system compounds",
+    r"the data tells us",
+    r"the question is whether",
+    r"\bNo [^.]+\. No [^.]+\. No [^.]+\.",
+    r"actually",
+    r"literally",
+    r"quietly",
+    r"unlock (?:the )?power",
+    r"delve",
+    r"in today's (?:fast-paced|digital)",
+    r"revolutionary",
+    r"best",
+    r"ultimate",
+    r"unparalleled",
+]
+
+
+def resolve_root(root: str | Path | None = None) -> Path:
+    if root:
+        return Path(root).expanduser().resolve()
+    cwd = Path.cwd().resolve()
+    if (cwd / "config.yaml").exists() and (cwd / "runs").exists():
+        return cwd
+    return cwd / "content-os"
+
+
+def slugify(title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return slug[:64].strip("-") or "untitled"
+
+
+def run_id_for(title: str) -> str:
+    return f"{datetime.now(timezone.utc):%Y-%m}-{slugify(title)}"
+
+
+def init(root: Path, force: bool = False) -> list[Path]:
+    created: list[Path] = []
+    for d in STRUCTURE_DIRS:
+        (root / d).mkdir(parents=True, exist_ok=True)
+    for rel, text in TEMPLATES.items():
+        if write_if_missing(root / rel, text, force=force):
+            created.append(root / rel)
+    example = root / "runs" / "archive" / "example-bookmarkable-content-system"
+    example.mkdir(parents=True, exist_ok=True)
+    write_if_missing(
+        example / "content-object.yaml",
+        dump_yaml(
+            ContentObject(
+                id="example-bookmarkable-content-system",
+                title="Example: bookmarkable content system",
+                slug="example-bookmarkable-content-system",
+                route="ORIGINAL",
+                state="archived",
+                files={"idea": "idea.md"},
+            ).model_dump()
+        ),
+        force=force,
+    )
+    write_if_missing(
+        example / "idea.md",
+        "# Idea\n\nA local-first workflow for turning ideas into approval-gated content.\n",
+        force=force,
+    )
+    return created
+
+
+def load_config(root: Path) -> dict[str, Any]:
+    cfg = load_yaml(root / "config.yaml")
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def run_dir(root: Path, run_id: str) -> Path:
+    for base in (root / "runs" / "active", root / "runs" / "archive"):
+        p = base / run_id
+        if p.exists():
+            return p
+    return root / "runs" / "active" / run_id
+
+
+def load_object(path: Path) -> ContentObject:
+    return ContentObject(**load_yaml(path / "content-object.yaml"))
+
+
+def save_object(path: Path, obj: ContentObject) -> None:
+    obj.updated_at = now_iso()
+    atomic_write(path / "content-object.yaml", dump_yaml(obj.model_dump()), backup=True)
+
+
+def create_run(
+    root: Path,
+    title: str,
+    route: str = "auto",
+    fmt: str = "x_post",
+    source: str | None = None,
+    text: str = "",
+) -> Path:
+    rid = run_id_for(title)
+    path = root / "runs" / "active" / rid
+    i = 2
+    while path.exists():
+        path = root / "runs" / "active" / f"{rid}-{i}"
+        i += 1
+    path.mkdir(parents=True)
+    obj = ContentObject(
+        id=path.name,
+        title=title,
+        slug=path.name,
+        route=route,
+        format=fmt,
+        state=State.idea_review.value,
+        source=source,
+        files={
+            "idea": "idea.md",
+            "brief": "brief.md",
+            "draft": "draft-package.md",
+            "verification": "verification.md",
+            "review": "review.md",
+            "scheduler_handoff": "scheduler-handoff.md",
+            "feedback": "feedback.md",
+        },
+    )
+    atomic_write(path / "content-object.yaml", dump_yaml(obj.model_dump()))
+    atomic_write(
+        path / "idea.md",
+        f"# Idea\n\nTitle: {title}\n\n{text or 'TODO: Describe the idea, source material, proof, and intended reader.'}\n",
+    )
+    return path
+
+
+def adapter_rules_path(root: Path) -> Path:
+    return root / "integrations" / "source-adapters.json"
+
+
+def _adapter_rule_items(root: Path) -> tuple[list[Any], list[str]]:
+    path = adapter_rules_path(root)
+    if not path.exists():
+        return [], []
+    try:
+        data = json.loads(read_text(path) or "[]")
+    except json.JSONDecodeError as exc:
+        return [], [f"Malformed adapter registry JSON: {path.relative_to(root)}: {exc}"]
+    if not isinstance(data, list):
+        return [], ["Adapter registry must be a JSON list of rule objects."]
+    return data, []
+
+
+def validate_adapter_rules(root: Path) -> list[str]:
+    data, issues = _adapter_rule_items(root)
+    seen_names: set[str] = set()
+    for index, item in enumerate(data):
+        prefix = f"Adapter rule #{index + 1}"
+        if not isinstance(item, dict):
+            issues.append(f"{prefix} must be an object.")
+            continue
+        name = str(item.get("name") or "").strip()
+        if not name:
+            issues.append(f"{prefix} is missing name.")
+        elif name in seen_names:
+            issues.append(f"{prefix} duplicates adapter rule name: {name}")
+        seen_names.add(name)
+        extensions = item.get("extensions")
+        if not isinstance(extensions, list) or not extensions:
+            issues.append(f"{prefix} must declare a non-empty extensions list.")
+        else:
+            bad_ext = [
+                ext
+                for ext in extensions
+                if not isinstance(ext, str) or not ext.startswith(".")
+            ]
+            if bad_ext:
+                issues.append(f"{prefix} has invalid extensions: {bad_ext}")
+        if not str(item.get("source_type") or "").strip():
+            issues.append(f"{prefix} is missing source_type.")
+        route = str(item.get("route") or "REPURPOSE")
+        if route not in VALID_ROUTES:
+            issues.append(f"{prefix} has invalid route: {route}")
+        fmt = str(item.get("format") or "custom")
+        if fmt not in VALID_FORMATS:
+            issues.append(f"{prefix} has invalid format: {fmt}")
+        for key in ("text_keys", "title_keys"):
+            if key in item and not isinstance(item[key], list):
+                issues.append(f"{prefix} {key} must be a list when provided.")
+    return issues
+
+
+def load_adapter_rules(root: Path) -> list[AdapterRule]:
+    data, _issues = _adapter_rule_items(root)
+    rules: list[AdapterRule] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        extensions = {
+            str(ext).lower()
+            for ext in item.get("extensions", [])
+            if isinstance(ext, str) and ext.startswith(".")
+        }
+        if (
+            not extensions
+            or str(item.get("route") or "REPURPOSE") not in VALID_ROUTES
+            or str(item.get("format") or "custom") not in VALID_FORMATS
+        ):
+            continue
+        rules.append(
+            AdapterRule(
+                name=str(item.get("name") or "custom-rule"),
+                extensions=extensions,
+                source_type=str(item.get("source_type") or "custom_source"),
+                text_keys=(
+                    [str(k) for k in item.get("text_keys", [])]
+                    if isinstance(item.get("text_keys", []), list)
+                    else []
+                ),
+                title_keys=(
+                    [str(k) for k in item.get("title_keys", [])]
+                    if isinstance(item.get("title_keys", []), list)
+                    else []
+                ),
+                route=str(item.get("route") or "REPURPOSE"),
+                format=str(item.get("format") or "custom"),
+                treat_as_text=bool(item.get("treat_as_text", True)),
+            )
+        )
+    return rules
+
+
+def adapter_inventory(root: Path) -> list[dict[str, Any]]:
+    builtins = [
+        {"name": "json", "kind": "built-in", "extensions": [".json", ".jsonl"]},
+        {"name": "csv", "kind": "built-in", "extensions": [".csv"]},
+        {
+            "name": "text",
+            "kind": "built-in",
+            "extensions": sorted([".txt", ".md", ".markdown", ".log", ".srt", ".vtt"]),
+        },
+        {"name": "pdf", "kind": "built-in", "extensions": [".pdf"]},
+        {
+            "name": "media_manifest",
+            "kind": "built-in",
+            "extensions": sorted(
+                [
+                    ".mp3",
+                    ".wav",
+                    ".m4a",
+                    ".flac",
+                    ".mp4",
+                    ".mov",
+                    ".mkv",
+                    ".avi",
+                    ".jpg",
+                    ".jpeg",
+                    ".png",
+                    ".webp",
+                ]
+            ),
+        },
+    ]
+    custom = [
+        {
+            "name": rule.name,
+            "kind": "rule",
+            "extensions": sorted(rule.extensions),
+            "source_type": rule.source_type,
+            "route": rule.route,
+            "format": rule.format,
+        }
+        for rule in load_adapter_rules(root)
+    ]
+    return custom + builtins
+
+
+def source_manifest_path(root: Path) -> Path:
+    return root / "stores" / "proof" / "source-manifest.json"
+
+
+def record_source_manifest(
+    root: Path, source: SourceDocument, proof_path: Path | None, run_path: Path | None
+) -> None:
+    manifest_path = source_manifest_path(root)
+    existing = load_yaml(manifest_path)
+    records = existing.get("sources", []) if isinstance(existing, dict) else []
+    records = [
+        record for record in records if record.get("source_id") != source.source_id
+    ]
+    records.append(
+        {
+            "source_id": source.source_id,
+            "sha256": source.sha256,
+            "path": str(source.path),
+            "title": source.title,
+            "source_type": source.source_type,
+            "adapter": source.adapter,
+            "proof_path": str(proof_path.relative_to(root)) if proof_path else None,
+            "run_id": run_path.name if run_path else None,
+            "imported_at": now_iso(),
+            "warnings": source.warnings,
+        }
+    )
+    atomic_write(
+        manifest_path,
+        json.dumps({"sources": records}, indent=2) + "\n",
+        backup=manifest_path.exists(),
+    )
+
+
+def proof_path_for_source(root: Path, source: SourceDocument) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    base = root / "stores" / "proof" / f"{stamp}-{slugify(source.title)}.md"
+    if not base.exists():
+        return base
+    suffix = 2
+    while True:
+        candidate = base.with_name(f"{base.stem}-{suffix}{base.suffix}")
+        if not candidate.exists():
+            return candidate
+        suffix += 1
+
+
+def store_source_as_proof(root: Path, source: SourceDocument) -> Path:
+    proof_path = proof_path_for_source(root, source)
+    atomic_write(proof_path, source.to_markdown(), backup=False)
+    return proof_path
+
+
+def import_source(
+    root: Path,
+    source_path: Path,
+    title: str | None = None,
+    route: str = "auto",
+    fmt: str = "custom",
+    as_proof: bool = True,
+    create_run_folder: bool = True,
+) -> tuple[Path | None, Path | None, SourceDocument]:
+    source = extract_source(source_path, rules=load_adapter_rules(root))
+    if title:
+        source.title = title
+    proof_path = store_source_as_proof(root, source) if as_proof else None
+    selected_route = source.suggested_route if route == "auto" else route
+    idea_text = f"""Imported local source: `{source.path}`
+
+Detected source type: {source.source_type}
+Suggested route: {source.suggested_route}
+
+Use only the extracted proof below, the proof store entry, and other user-approved context. Do not invent missing details.
+
+## Extracted source
+{source.text[:12000]}
+"""
+    if proof_path:
+        idea_text += f"\n\nProof store entry: `{proof_path.relative_to(root)}`\n"
+    run_path = None
+    if create_run_folder:
+        run_path = create_run(
+            root,
+            source.title,
+            route=selected_route,
+            fmt=fmt,
+            source=str(source.path),
+            text=idea_text,
+        )
+        obj = load_object(run_path)
+        obj.attribution = {
+            "source_id": source.source_id,
+            "source_path": str(source.path),
+            "source_type": source.source_type,
+            "sha256": source.sha256,
+            "adapter": source.adapter,
+            "imported_at": now_iso(),
+        }
+        if proof_path:
+            obj.files["imported_proof"] = str(proof_path.relative_to(root))
+        obj.assumptions.extend(source.warnings)
+        obj.next_action = (
+            "Review imported source, attribution, and route before briefing."
+        )
+        save_object(run_path, obj)
+    if proof_path or run_path:
+        record_source_manifest(root, source, proof_path, run_path)
+    return run_path, proof_path, source
+
+
+def scan_inputs(
+    root: Path, path: Path, out: Path | None = None, limit: int | None = None
+) -> tuple[list[SourceDocument], Path | None]:
+    cfg = load_config(root).get("input_ingest", {})
+    max_files = int(cfg.get("max_scan_files", 100)) if isinstance(cfg, dict) else 100
+    docs = scan_path(path, limit=limit or max_files, rules=load_adapter_rules(root))
+    report = scan_report(path, docs)
+    report_path = out
+    if report_path:
+        atomic_write(report_path, report, backup=report_path.exists())
+    return docs, report_path
+
+
+def capture(
+    root: Path,
+    title: str,
+    text: str,
+    source: str | None,
+    route: str,
+    create_run_folder: bool = True,
+) -> Path | None:
+    ts = now_iso()
+    rid = run_id_for(title)
+    entry = f"\n## {title}\n\n- id: {rid}\n- captured_at: {ts}\n- source: {source or 'manual'}\n- route_hint: {route}\n- status: captured\n\n{text}\n"
+    append(root / "stores" / "inbox.md", entry)
+    if not create_run_folder:
+        return None
+    path = create_run(root, title, route=route, source=source, text=text)
+    obj = load_object(path)
+    obj.state = State.captured.value
+    obj.next_action = "Move to idea_review with new-run or edit content-object.yaml."
+    save_object(path, obj)
+    return path
+
+
+def classify_route(text: str) -> tuple[str, str]:
+    t = text.lower()
+    if any(w in t for w in ["research", "explore", "ideas about", "candidate ideas"]):
+        return "RESEARCH_IDEATE", "Heuristic saw research/ideation language."
+    if any(w in t for w in ["rewrite", "external", "source:", "attribution", "link:"]):
+        return "REWRITE", "Heuristic saw external source or rewrite language."
+    if any(
+        w in t
+        for w in [
+            "repurpose",
+            "transcript",
+            "article",
+            "newsletter",
+            "old post",
+            "convert",
+        ]
+    ):
+        return (
+            "REPURPOSE",
+            "Heuristic saw user-owned source material conversion language.",
+        )
+    return (
+        "ORIGINAL",
+        "Heuristic defaulted to original user viewpoint. Edit content-object.yaml if wrong.",
+    )
+
+
+def route_run(root: Path, rid: str) -> str:
+    path = run_dir(root, rid)
+    obj = load_object(path)
+    idea = read_text(path / "idea.md")
+    if obj.route == "auto":
+        obj.route, reason = classify_route(idea)
+        if not llm_configured():
+            reason += " No LLM is configured, so deterministic heuristics were used; edit content-object.yaml manually if needed."
+    else:
+        reason = "Route was already set manually."
+    if obj.route == "REWRITE" and not obj.attribution:
+        obj.assumptions.append(
+            "REWRITE route needs attribution metadata before approval."
+        )
+    if obj.route == "RESEARCH_IDEATE":
+        ideas_path = root / "stores" / "ideas" / f"{rid}.md"
+        atomic_write(
+            ideas_path,
+            f"# Candidate ideas from {obj.title}\n\nSource run: {rid}\n\n{idea}\n",
+            backup=ideas_path.exists(),
+        )
+        obj.next_action = (
+            "Review candidate ideas in stores/ideas before creating a final-post run."
+        )
+    else:
+        obj.next_action = "Create writer brief."
+    save_object(path, obj)
+    return reason
+
+
+def context_snippet(root: Path, rel: str, limit: int = 1200) -> str:
+    return read_text(root / rel).strip()[:limit]
+
+
+def make_brief(root: Path, rid: str) -> Path:
+    path = run_dir(root, rid)
+    obj = load_object(path)
+    idea = read_text(path / "idea.md")
+    proof_files = sorted((root / "stores" / "proof").glob("*.md"))[:5]
+    hooks_files = sorted((root / "stores" / "hooks").glob("*.md"))[:5]
+    proof = (
+        "\n".join(f"## {p.name}\n{read_text(p)[:800]}" for p in proof_files)
+        or "No proof files supplied yet."
+    )
+    hooks = (
+        "\n".join(f"- {read_text(p)[:160].strip()}" for p in hooks_files)
+        or "No hook files supplied yet."
+    )
+    body = f"""# Writer Context Packet: {obj.title}
+
+## thesis
+TODO: One sentence the post must prove. Start from the idea below; do not invent facts.
+
+## reader
+{context_snippet(root, 'strategy/audience.md')}
+
+## proof
+Allowed proof only. Do not invent facts, metrics, clients, screenshots, or examples.
+
+{proof}
+
+## angle
+TODO: Unexpected framing based on the idea and positioning.
+
+## constraints
+- format: {obj.format}
+- route: {obj.route}
+- banned phrases and slop checks: see voice/master-avoid-slop.md
+- attribution required for REWRITE: {'yes' if obj.route == 'REWRITE' else 'no unless a source is used'}
+
+## voice anchors
+{context_snippet(root, 'voice/voice-profile.md')}
+
+## risks
+{context_snippet(root, 'voice/master-avoid-slop.md')}
+
+## open loops
+- Confirm thesis, proof, attribution, and any missing source details.
+- LLM-disabled drafts must remain placeholders until a human fills them.
+
+## source idea
+{idea}
+
+## positioning and pillars
+{context_snippet(root, 'strategy/positioning.md')}
+
+{context_snippet(root, 'strategy/pillars.md')}
+
+## hook references
+{hooks}
+"""
+    atomic_write(path / "brief.md", body, backup=True)
+    obj.transition(State.brief_ready.value, force=True)
+    obj.next_action = "Draft from brief."
+    save_object(path, obj)
+    return path / "brief.md"
+
+
+def llm_configured() -> bool:
+    return bool(
+        os.getenv("CONTENT_OS_LLM_BASE_URL") and os.getenv("CONTENT_OS_LLM_MODEL")
+    )
+
+
+def call_llm(prompt: str) -> str:
+    base = os.getenv("CONTENT_OS_LLM_BASE_URL", "").rstrip("/")
+    key = os.getenv("CONTENT_OS_LLM_API_KEY", "")
+    payload = {
+        "model": os.getenv("CONTENT_OS_LLM_MODEL"),
+        "temperature": float(os.getenv("CONTENT_OS_LLM_TEMPERATURE", "0.4")),
+        "max_tokens": int(os.getenv("CONTENT_OS_LLM_MAX_TOKENS", "1200")),
+        "messages": [
+            {
+                "role": "system",
+                "content": "You draft approval-gated creator content. Do not invent proof.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+    }
+    req = urllib.request.Request(
+        f"{base}/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {key}"},
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        data = json.loads(resp.read().decode())
+    return data["choices"][0]["message"]["content"]
+
+
+def draft(root: Path, rid: str) -> Path:
+    path = run_dir(root, rid)
+    obj = load_object(path)
+    brief = read_text(path / "brief.md")
+    if llm_configured():
+        candidate = call_llm(
+            f"Create draft-package.md with required sections from this brief:\n\n{brief}"
+        )
+    else:
+        candidate = f"""# Draft Package: {obj.title}
+
+## final draft candidate
+TODO: Write the final {obj.format} after reviewing the brief. No LLM is configured, so this placeholder avoids inventing proof.
+
+## alternate hooks
+- TODO: Hook tied to the reader's job-to-be-done.
+- TODO: Hook using a concrete artifact or proof point.
+- TODO: Hook that frames the cost of the current workflow.
+
+## source/proof checklist
+- [ ] Every claim maps to proof in brief.md or user knowledge.
+- [ ] Attribution is present for external signals.
+- [ ] No invented metrics, clients, screenshots, or outcomes.
+
+## known assumptions
+- Draft copy is incomplete until a human fills TODOs.
+
+## suggested visuals
+- Screenshot, checklist, workflow diagram, or annotated artifact from approved proof.
+
+## platform format notes
+- Target format: {obj.format}
+- Keep the opening specific and useful.
+"""
+    atomic_write(
+        path / "draft-package.md",
+        candidate if candidate.startswith("#") else "# Draft Package\n\n" + candidate,
+        backup=True,
+    )
+    obj.transition(State.drafting.value, force=True)
+    obj.next_action = "Run verification."
+    save_object(path, obj)
+    return path / "draft-package.md"
+
+
+def avoid_slop(text: str) -> list[str]:
+    issues = []
+    for pat in BANNED_PATTERNS:
+        if re.search(pat, text, flags=re.IGNORECASE):
+            issues.append(pat)
+    if text.count("—") > 3:
+        issues.append("em dash overuse")
+    return issues
+
+
+def score_draft(text: str) -> list[tuple[str, int, str]]:
+    lower = text.lower()
+    heuristics = [
+        any(w in lower for w in ["save", "checklist", "workflow", "template", "reuse"]),
+        any(
+            w in lower
+            for w in ["proof", "example", "screenshot", "number", "metric", "case"]
+        ),
+        any(
+            w in lower
+            for w in ["template", "checklist", "framework", "workflow", "mental model"]
+        ),
+        any(
+            w in lower
+            for w in ["reader", "founder", "operator", "creator", "job-to-be-done"]
+        ),
+        any(w in lower for w in ["step", "apply", "copy", "use this", "without"]),
+        any(
+            w in lower
+            for w in ["visual", "screenshot", "artifact", "diagram", "example"]
+        ),
+    ]
+    rows = []
+    for item, ok in zip(SCORE_ITEMS, heuristics):
+        score = 2 if ok else 0
+        rows.append(
+            (
+                item,
+                score,
+                "Heuristic evidence found." if ok else "Missing or too vague.",
+            )
+        )
+    return rows
+
+
+def verify(root: Path, rid: str) -> Path:
+    path = run_dir(root, rid)
+    obj = load_object(path)
+    text = read_text(path / "draft-package.md")
+    rows = score_draft(text)
+    total = sum(r[1] for r in rows)
+    threshold = int(load_config(root).get("score_threshold", DEFAULT_SCORE_THRESHOLD))
+    banned = avoid_slop(text)
+    passed = total >= threshold and not banned and "TODO" not in text
+    md = [
+        f"# Verification: {obj.title}",
+        "",
+        "## score breakdown",
+        "",
+        "| Item | Score | Notes |",
+        "|---|---:|---|",
+    ]
+    md += [f"| {item} | {score} | {note} |" for item, score, note in rows]
+    md += [
+        "",
+        f"## total\n{total}/12",
+        "",
+        f"## pass/fail\n{'PASS' if passed else 'FAIL'} (threshold: {threshold}/12)",
+        "",
+        "## exact issues",
+    ]
+    if not passed:
+        if total < threshold:
+            md.append(f"- Score below threshold by {threshold-total} point(s).")
+        if "TODO" in text:
+            md.append("- Draft still contains TODO placeholders.")
+        for b in banned:
+            md.append(f"- Banned phrase/pattern matched: `{b}`")
+    else:
+        md.append("- None detected by deterministic checks.")
+    md += [
+        "",
+        "## suggested fixes",
+        "- Add concrete proof and reusable artifacts where scores are low.",
+        "- Remove banned phrases and unsupported claims.",
+        "",
+        "## banned phrase matches",
+    ]
+    md += [f"- `{b}`" for b in banned] or ["- None"]
+    md += [
+        "",
+        "## required human review note",
+        "Human approval is required before any scheduler handoff or Postiz export can be used for publishing.",
+    ]
+    atomic_write(path / "verification.md", "\n".join(md) + "\n", backup=True)
+    obj.score = total
+    obj.transition(State.verification.value, force=True)
+    obj.next_action = "Human review and approval."
+    save_object(path, obj)
+    return path / "verification.md"
+
+
+def verification_passed(path: Path) -> bool:
+    return "## pass/fail\nPASS" in read_text(path / "verification.md")
+
+
+def approve(root: Path, rid: str, force: bool = False, reason: str = "") -> None:
+    path = run_dir(root, rid)
+    obj = load_object(path)
+    passed = verification_passed(path)
+    if not passed and not force:
+        raise ValueError(
+            "Verification failed; use --force with --reason to approve anyway."
+        )
+    if not passed and force and not reason.strip():
+        raise ValueError("Forced approval of failed verification requires --reason.")
+    obj.transition(State.human_review.value, force=True)
+    obj.transition(State.approved.value)
+    obj.human_approved = True
+    obj.next_action = "Create scheduler handoff."
+    append(
+        path / "review.md",
+        f"\n## Approval {now_iso()}\n- forced: {force}\n- reason: {reason or 'Verification passed'}\n",
+    )
+    save_object(path, obj)
+
+
+def make_payload(obj: ContentObject, draft_text: str, platform: str) -> dict[str, Any]:
+    return {
+        "requires_manual_review": True,
+        "approval_status": "approved" if obj.human_approved else "not_approved",
+        "platform": platform,
+        "title": obj.title,
+        "content": draft_text,
+        "attribution": obj.attribution,
+        "utm": {"campaign": obj.slug, "source": platform, "medium": "social"},
+        "postiz_note": "Create a draft/queue item only; do not auto-publish.",
+    }
+
+
+def scheduler_handoff(root: Path, rid: str, platform: str) -> Path:
+    path = run_dir(root, rid)
+    obj = load_object(path)
+    if not obj.human_approved or obj.state not in {
+        State.approved.value,
+        State.scheduler_ready.value,
+    }:
+        raise ValueError("Scheduler handoff requires approved run.")
+    draft_text = read_text(path / "draft-package.md")
+    payload = make_payload(obj, draft_text, platform)
+    md = f"""# Scheduler Handoff: {obj.title}
+
+## final approved copy
+{draft_text}
+
+## platform
+{platform}
+
+## suggested publish window
+{load_config(root).get('default_publish_window', 'Manual choice required')}
+
+## media/assets needed
+TODO: Attach approved assets manually.
+
+## attribution
+```json
+{json.dumps(obj.attribution, indent=2)}
+```
+
+## UTM/campaign fields
+- campaign: {obj.slug}
+- source: {platform}
+- medium: social
+
+## Postiz-ready payload JSON
+```json
+{json.dumps(payload, indent=2)}
+```
+"""
+    atomic_write(path / "scheduler-handoff.md", md, backup=True)
+    if obj.state != State.scheduler_ready.value:
+        obj.transition(State.scheduler_ready.value)
+    obj.next_action = "Export payload or schedule manually."
+    save_object(path, obj)
+    return path / "scheduler-handoff.md"
+
+
+def postiz_export(root: Path, rid: str, out: Path, platform: str = "custom") -> None:
+    path = run_dir(root, rid)
+    obj = load_object(path)
+    if not obj.human_approved:
+        raise ValueError("Postiz export requires approved run.")
+    payload = make_payload(obj, read_text(path / "draft-package.md"), platform)
+    atomic_write(out, json.dumps(payload, indent=2) + "\n", backup=out.exists())
+
+
+def feedback(
+    root: Path,
+    rid: str,
+    views: int,
+    bookmarks: int,
+    likes: int,
+    replies: int,
+    reposts: int,
+    notes: str = "",
+) -> dict[str, float]:
+    path = run_dir(root, rid)
+    obj = load_object(path)
+    br = bookmarks / views if views else 0
+    rr = replies / views if views else 0
+    er = (likes + replies + reposts + bookmarks) / views if views else 0
+    md = f"# Feedback: {obj.title}\n\n- views: {views}\n- bookmarks: {bookmarks}\n- likes: {likes}\n- replies: {replies}\n- reposts: {reposts}\n- bookmark_rate: {br:.6f}\n- reply_rate: {rr:.6f}\n- engagement_rate: {er:.6f}\n\n## qualitative notes\n{notes}\n\n## proposed lessons\n- Review hooks, proof density, and avoid-slop matches. Proposed voice changes must be manually copied into voice rules.\n"
+    atomic_write(path / "feedback.md", md, backup=True)
+    cfg = load_config(root)
+    dest_base = (
+        root
+        / "stores"
+        / (
+            "winners"
+            if br >= float(cfg.get("winning_bookmark_rate", WIN_BOOKMARK_RATE))
+            else (
+                "losers"
+                if br <= float(cfg.get("losing_bookmark_rate", LOSE_BOOKMARK_RATE))
+                else "feedback"
+            )
+        )
+    )
+    atomic_write(dest_base / f"{rid}.md", md, backup=True)
+    obj.next_action = "Archive after lessons are reviewed."
+    save_object(path, obj)
+    return {"bookmark_rate": br, "reply_rate": rr, "engagement_rate": er}
+
+
+def archive(root: Path, rid: str, force: bool = False) -> Path:
+    src = root / "runs" / "active" / rid
+    obj = load_object(src)
+    if (
+        obj.state
+        not in [
+            State.approved.value,
+            State.published.value,
+            State.learned.value,
+            State.scheduler_ready.value,
+        ]
+        and not force
+    ):
+        raise ValueError("Refusing to archive unfinished work without --force.")
+    if force:
+        append(
+            src / "review.md",
+            f"\n## Forced archive {now_iso()}\n- previous_state: {obj.state}\n",
+        )
+    dest = root / "runs" / "archive" / rid
+    if dest.exists():
+        raise ValueError("Archive destination already exists.")
+    obj.transition(State.archived.value, force=True)
+    save_object(src, obj)
+    shutil.move(str(src), str(dest))
+    return dest
+
+
+def status(root: Path) -> list[ContentObject]:
+    return [
+        load_object(p)
+        for p in sorted((root / "runs" / "active").glob("*/"))
+        if (p / "content-object.yaml").exists()
+    ]
+
+
+def doctor(root: Path) -> list[str]:
+    issues = []
+    for d in STRUCTURE_DIRS:
+        if not (root / d).is_dir():
+            issues.append(f"Missing directory: {d}")
+    for rel in TEMPLATES:
+        if not (root / rel).exists():
+            issues.append(f"Missing file: {rel}")
+    for y in list(root.glob("**/*.yaml")) + list(root.glob("**/*.yml")):
+        try:
+            load_yaml(y)
+        except Exception as e:
+            issues.append(f"Malformed YAML: {y.relative_to(root)}: {e}")
+    issues.extend(validate_adapter_rules(root))
+    if not llm_configured():
+        issues.append("LLM not configured; placeholder drafting mode is active.")
+    return issues

--- a/content_os/io.py
+++ b/content_os/io.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+yaml = None
+if importlib.util.find_spec("yaml") is not None:
+    import yaml  # type: ignore
+
+
+def atomic_write(path: Path, text: str, *, backup: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if backup and path.exists():
+        shutil.copy2(path, path.with_suffix(path.suffix + ".bak"))
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(text)
+    os.replace(tmp, path)
+
+
+def write_if_missing(path: Path, text: str, *, force: bool = False) -> bool:
+    if path.exists() and not force:
+        return False
+    atomic_write(path, text, backup=path.exists())
+    return True
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    txt = read_text(path)
+    if yaml:
+        data = yaml.safe_load(txt)
+        return data or {}
+    try:
+        return json.loads(txt or "{}")
+    except json.JSONDecodeError:
+        data: dict[str, Any] = {}
+        for line in txt.splitlines():
+            if not line.strip() or line.lstrip().startswith("#") or ":" not in line:
+                continue
+            k, v = line.split(":", 1)
+            v = v.strip().strip("'\"")
+            if v.lower() in {"true", "false"}:
+                parsed: Any = v.lower() == "true"
+            else:
+                try:
+                    parsed = int(v) if v.isdigit() else float(v)
+                except ValueError:
+                    parsed = v
+            data[k.strip()] = parsed
+        return data
+
+
+def dump_yaml(data: Any) -> str:
+    clean = json.loads(json.dumps(data))
+    if yaml:
+        return yaml.safe_dump(clean, sort_keys=False, allow_unicode=True)
+    return json.dumps(clean, indent=2) + "\n"
+
+
+def append(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(text)

--- a/content_os/models.py
+++ b/content_os/models.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import importlib.util
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+_PYDANTIC = importlib.util.find_spec("pydantic") is not None
+
+if (
+    _PYDANTIC
+):  # Prefer pydantic when installed; keep CLI local-first without network/deps.
+    from pydantic import BaseModel, Field
+else:
+    BaseModel = object  # type: ignore
+
+    def Field(default_factory=None, default=None):  # type: ignore
+        return (
+            field(default_factory=default_factory)
+            if default_factory
+            else field(default=default)
+        )
+
+
+class Route(str, Enum):
+    auto = "auto"
+    ORIGINAL = "ORIGINAL"
+    REPURPOSE = "REPURPOSE"
+    REWRITE = "REWRITE"
+    RESEARCH_IDEATE = "RESEARCH_IDEATE"
+
+
+class Format(str, Enum):
+    x_post = "x_post"
+    x_thread = "x_thread"
+    linkedin = "linkedin"
+    blog = "blog"
+    newsletter = "newsletter"
+    custom = "custom"
+
+
+class State(str, Enum):
+    captured = "captured"
+    idea_review = "idea_review"
+    brief_ready = "brief_ready"
+    drafting = "drafting"
+    verification = "verification"
+    human_review = "human_review"
+    approved = "approved"
+    scheduler_ready = "scheduler_ready"
+    scheduled = "scheduled"
+    published = "published"
+    feedback_24h = "feedback_24h"
+    feedback_72h = "feedback_72h"
+    learned = "learned"
+    archived = "archived"
+
+
+STATE_ORDER = [s.value for s in State]
+ALLOWED_TRANSITIONS = dict(zip(STATE_ORDER, STATE_ORDER[1:]))
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+if _PYDANTIC:
+
+    class ContentObject(BaseModel):
+        id: str
+        title: str
+        slug: str
+        route: str = Route.auto.value
+        format: str = Format.x_post.value
+        state: str = State.idea_review.value
+        created_at: str = Field(default_factory=now_iso)
+        updated_at: str = Field(default_factory=now_iso)
+        source: str | None = None
+        platform_targets: list[str] = Field(default_factory=list)
+        score: int | None = None
+        next_action: str = "Review idea and confirm route."
+        human_approved: bool = False
+        assumptions: list[str] = Field(default_factory=list)
+        attribution: dict[str, Any] = Field(default_factory=dict)
+        files: dict[str, str] = Field(default_factory=dict)
+
+        def model_dump(self) -> dict[str, Any]:
+            # Compatibility shim for pydantic v1/v2 without forcing a dependency pin.
+            if hasattr(super(), "model_dump"):
+                return super().model_dump()  # type: ignore[misc]
+            return self.dict()
+
+        def transition(self, new_state: str, *, force: bool = False) -> bool:
+            return _transition(self, new_state, force=force)
+
+else:
+
+    @dataclass
+    class ContentObject:  # type: ignore[no-redef]
+        id: str
+        title: str
+        slug: str
+        route: str = Route.auto.value
+        format: str = Format.x_post.value
+        state: str = State.idea_review.value
+        created_at: str = field(default_factory=now_iso)
+        updated_at: str = field(default_factory=now_iso)
+        source: str | None = None
+        platform_targets: list[str] = field(default_factory=list)
+        score: int | None = None
+        next_action: str = "Review idea and confirm route."
+        human_approved: bool = False
+        assumptions: list[str] = field(default_factory=list)
+        attribution: dict[str, Any] = field(default_factory=dict)
+        files: dict[str, str] = field(default_factory=dict)
+
+        def model_dump(self) -> dict[str, Any]:
+            return asdict(self)
+
+        def transition(self, new_state: str, *, force: bool = False) -> bool:
+            return _transition(self, new_state, force=force)
+
+
+def _transition(obj: ContentObject, new_state: str, *, force: bool = False) -> bool:
+    old = obj.state
+    if old == new_state:
+        return False
+    expected = ALLOWED_TRANSITIONS.get(old)
+    if expected == new_state or force:
+        obj.state = new_state
+        obj.updated_at = now_iso()
+        return True
+    raise ValueError(
+        f"Invalid state transition: {old} -> {new_state}; expected {expected!r} or force=True"
+    )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,105 @@
+# Content OS Architecture
+
+This document describes how the local-first Content OS implementation is organized, where safety gates live, and how autoingest repository outputs flow into proof-backed content runs.
+
+## System diagram
+
+```mermaid
+flowchart TD
+  User[Human creator / operator]
+  CLI[content-os CLI\ncontent_os.cli]
+  Core[Workflow engine\ncontent_os.core]
+  Models[Content object + state machine\ncontent_os.models]
+  IO[Atomic file IO + YAML/JSON fallback\ncontent_os.io]
+  Adapters[Input adapters\ncontent_os.adapters]
+  LLM[Optional OpenAI-compatible LLM\nCONTENT_OS_LLM_*]
+  Postiz[Postiz handoff JSON\nmanual review required]
+
+  Files[(content-os/ file tree)]
+  Strategy[strategy/ + voice/]
+  Stores[stores/\ninbox, proof, ideas, hooks, feedback]
+  Runs[runs/active/YYYY-MM-slug]
+  Archive[runs/archive]
+  LocalInputs[User-owned local inputs\ntranscripts, summaries, CSV/JSON, PDFs, media manifests]
+
+  User --> CLI
+  CLI --> Core
+  Core --> Models
+  Core --> IO
+  IO --> Files
+  Files --> Strategy
+  Files --> Stores
+  Files --> Runs
+  Files --> Archive
+
+  LocalInputs --> Adapters
+  Adapters --> Core
+  Core --> Stores
+  Core --> Runs
+
+  Strategy --> Core
+  Stores --> Core
+  Runs --> Core
+  Core -. draft only when configured .-> LLM
+  LLM -. draft text .-> Core
+  Core -->|approved runs only| Postiz
+  Postiz --> User
+```
+
+## Lifecycle gate diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> captured
+  captured --> idea_review
+  idea_review --> brief_ready
+  brief_ready --> drafting
+  drafting --> verification
+  verification --> human_review
+  human_review --> approved
+  approved --> scheduler_ready
+  scheduler_ready --> scheduled
+  scheduled --> published
+  published --> feedback_24h
+  feedback_24h --> feedback_72h
+  feedback_72h --> learned
+  learned --> archived
+
+  verification --> human_review: verification PASS
+  verification --> human_review: --force + reason for failed verification
+  approved --> scheduler_ready: scheduler-handoff only after human approval
+  scheduler_ready --> approved: no automatic back-transition
+```
+
+## Module responsibilities
+
+| Module | Responsibility | Safety boundary |
+|---|---|---|
+| `content_os.cli` | Parses command line arguments and maps commands to workflow functions. | Does not publish; `--send-to-postiz` is acknowledged as export-only in this implementation. |
+| `content_os.core` | Owns run folders, state updates, brief/draft/verify/approve/handoff/feedback/archive behavior. | Approval gates live here; scheduler handoff and Postiz export require `human_approved=true`. |
+| `content_os.models` | Defines routes, formats, lifecycle states, and `ContentObject`. | State transitions are constrained unless a command explicitly forces and records an exception. |
+| `content_os.io` | Performs atomic writes, backups, appends, and YAML/JSON serialization fallback. | Existing generated files are backed up where commands rewrite them. |
+| `content_os.adapters` | Converts user-provided local inputs into `SourceDocument` records through built-in adapters and declarative rules. | No scraping and no automatic media transcription; binary media becomes a manifest until a user supplies approved text/proof. |
+
+## Data flow
+
+1. `init` creates the Content OS folder tree and human-readable templates.
+2. `capture`, `new-run`, or `ingest-source` creates a content object under `runs/active/`.
+3. `scan-inputs` and `ingest-source` adapt autoingest outputs into `stores/proof/` and optional run folders. Dynamic adapter rules are read from `integrations/source-adapters.json`.
+4. `route` classifies the run, with deterministic heuristics when no LLM is configured.
+5. `brief` builds a compact writer context packet from strategy, voice, proof, hooks, and `idea.md`.
+6. `draft` either calls an OpenAI-compatible endpoint or writes a no-LLM TODO draft package.
+7. `verify` writes scorecard output, avoid-slop matches, exact issues, and required human review notes.
+8. `approve` requires passing verification or `--force --reason` for explicit human exception handling.
+9. `scheduler-handoff` and `postiz-export` produce handoff artifacts only after approval; they do not publish.
+10. `feedback` stores performance-derived lessons in winners/losers/feedback without automatically overwriting voice rules.
+
+## Autoingest integration stance
+
+The autoingest repository contains scripts for local transcription, metadata processing, media analysis, and summaries. Content OS treats outputs from those scripts as user-owned local inputs. It adapts them into proof and run folders but does not call platform scrapers, does not bypass platform rules, does not transcribe binary media by itself, and does not publish content.
+
+## Dynamic adapter rules and source manifest
+
+`content-os init` creates `integrations/source-adapters.json`. The file is a declarative adapter registry: each rule can claim one or more extensions, set the resulting source type, choose route/format defaults, and optionally name JSON keys to extract for title/text. Custom rules are evaluated before built-in adapters, so a team can add support for new exports without editing Python code.
+
+Every imported source gets a SHA-256 hash and stable `source_id`. `ingest-source` records those details in `stores/proof/source-manifest.json` alongside the proof path, run ID, adapter, warnings, and original local path. This makes proof lineage auditable and helps prevent accidental loss of attribution as new data sources are added. `doctor` validates the registry before production use, while scan/ingest fall back to built-in adapters if the registry is malformed so one bad rule does not block local proof capture.

--- a/examples/no_llm_workflow.md
+++ b/examples/no_llm_workflow.md
@@ -1,0 +1,15 @@
+# No-LLM workflow example
+
+```bash
+content-os init
+content-os new-run --title "Bookmarkable content systems for technical founders" --route ORIGINAL --format x_thread
+content-os brief 2026-05-bookmarkable-content-systems-for-technical-founders
+content-os draft 2026-05-bookmarkable-content-systems-for-technical-founders
+# Edit draft-package.md to replace TODOs with human-approved copy and proof.
+content-os verify 2026-05-bookmarkable-content-systems-for-technical-founders
+content-os approve 2026-05-bookmarkable-content-systems-for-technical-founders
+content-os scheduler-handoff 2026-05-bookmarkable-content-systems-for-technical-founders --platform x
+content-os postiz-export 2026-05-bookmarkable-content-systems-for-technical-founders --out ./postiz_payload.json
+```
+
+If verification fails, improve the draft rather than forcing approval. `--force` is reserved for explicit manual exceptions recorded in `review.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "content-os"
+version = "0.1.0"
+description = "Local-first, approval-gated content operating system CLI"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+full = ["pydantic>=2.6", "PyYAML>=6.0"]
+dev = ["pytest>=8.0"]
+
+[project.scripts]
+content-os = "content_os.cli:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+from content_os.adapters import extract_source, scan_path
+
+
+def test_subtitle_adapter_strips_timing_noise(tmp_path: Path):
+    subtitle = tmp_path / "clip.srt"
+    subtitle.write_text(
+        "1\n00:00:00,000 --> 00:00:02,000\nThis is the usable line.\n\n2\n00:00:02,000 --> 00:00:04,000\nAnother line.",
+        encoding="utf-8",
+    )
+
+    doc = extract_source(subtitle)
+
+    assert doc.source_type == "transcript"
+    assert "-->" not in doc.text
+    assert "This is the usable line." in doc.text
+    assert "Another line." in doc.text
+
+
+def test_csv_adapter_extracts_text_like_column(tmp_path: Path):
+    csv_file = tmp_path / "metadata.csv"
+    csv_file.write_text("id,notes\n1,Useful proof\n2,Second proof\n", encoding="utf-8")
+
+    doc = extract_source(csv_file)
+
+    assert doc.source_type == "tabular_export"
+    assert "Useful proof" in doc.text
+    assert doc.metadata["columns"] == ["id", "notes"]
+
+
+def test_media_adapter_creates_manifest_without_transcription(tmp_path: Path):
+    media = tmp_path / "dashcam.mp4"
+    media.write_bytes(b"not a real video")
+
+    doc = extract_source(media)
+
+    assert doc.source_type == "media_asset"
+    assert "not transcribed automatically" in " ".join(doc.warnings)
+    assert "Media asset captured as a manifest" in doc.text
+
+
+def test_scan_path_reports_malformed_json_without_stopping(tmp_path: Path):
+    bad = tmp_path / "bad.json"
+    good = tmp_path / "note.txt"
+    bad.write_text("{not json", encoding="utf-8")
+    good.write_text("usable note", encoding="utf-8")
+
+    docs = scan_path(tmp_path)
+
+    by_name = {doc.path.name: doc for doc in docs}
+    assert by_name["bad.json"].source_type == "unreadable"
+    assert by_name["note.txt"].source_type == "text_note"
+
+
+def test_rule_based_adapter_handles_custom_json_extension(tmp_path: Path):
+    from content_os.adapters import AdapterRule, extract_source
+
+    source = tmp_path / "custom.notejson"
+    source.write_text(
+        '{"title":"Custom Title","body":"Custom body proof"}', encoding="utf-8"
+    )
+    rule = AdapterRule(
+        name="notejson",
+        extensions={".notejson"},
+        source_type="custom_json_note",
+        text_keys=["body"],
+        title_keys=["title"],
+        route="REPURPOSE",
+    )
+
+    doc = extract_source(source, rules=[rule])
+
+    assert doc.adapter == "rule:notejson"
+    assert doc.source_type == "custom_json_note"
+    assert doc.title == "Custom Title"
+    assert doc.text == "Custom body proof"
+    assert doc.sha256

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+
+from content_os.cli import main
+
+
+def test_cli_init_capture_and_status(tmp_path: Path, capsys):
+    root = tmp_path / "content-os"
+
+    assert main(["init", "--root", str(root)]) == 0
+    assert (
+        main(
+            [
+                "--root",
+                str(root),
+                "capture",
+                "--title",
+                "CLI note",
+                "--text",
+                "raw",
+                "--no-run",
+            ]
+        )
+        == 0
+    )
+    assert main(["--root", str(root), "status"]) == 0
+
+    out = capsys.readouterr().out
+    assert "Initialized Content OS" in out
+    assert "captured_to_inbox" in out
+    assert "id" in out and "next_action" in out
+    assert "CLI note" in (root / "stores" / "inbox.md").read_text(encoding="utf-8")
+
+
+def test_cli_ingest_source_creates_proof_and_run(tmp_path: Path, capsys):
+    root = tmp_path / "content-os"
+    source = tmp_path / "segments.json"
+    source.write_text(
+        '{"title":"CLI Segments","segments":[{"start":0,"text":"CLI proof"}]}',
+        encoding="utf-8",
+    )
+
+    assert main(["init", "--root", str(root)]) == 0
+    assert (
+        main(
+            ["--root", str(root), "ingest-source", str(source), "--format", "linkedin"]
+        )
+        == 0
+    )
+
+    out = capsys.readouterr().out
+    assert "source_type=transcript_json" in out
+    assert "run=2026-05-cli-segments" in out
+    assert list((root / "stores" / "proof").glob("*cli-segments.md"))
+
+
+def test_cli_failed_approval_without_force_returns_error(tmp_path: Path, capsys):
+    root = tmp_path / "content-os"
+    assert main(["init", "--root", str(root)]) == 0
+    assert (
+        main(
+            [
+                "--root",
+                str(root),
+                "new-run",
+                "--title",
+                "Needs work",
+                "--route",
+                "ORIGINAL",
+            ]
+        )
+        == 0
+    )
+    run_id = "2026-05-needs-work"
+    draft = root / "runs" / "active" / run_id / "draft-package.md"
+    draft.write_text("TODO groundbreaking", encoding="utf-8")
+    assert main(["--root", str(root), "verify", run_id]) == 0
+
+    assert main(["--root", str(root), "approve", run_id]) == 2
+    err = capsys.readouterr().err
+    assert "Verification failed" in err
+
+
+def test_cli_scan_inputs_writes_report(tmp_path: Path):
+    root = tmp_path / "content-os"
+    inputs = tmp_path / "inputs"
+    inputs.mkdir()
+    (inputs / "note.md").write_text("# Note\n\nProof", encoding="utf-8")
+    report = tmp_path / "scan.md"
+
+    assert main(["init", "--root", str(root)]) == 0
+    assert (
+        main(["--root", str(root), "scan-inputs", str(inputs), "--out", str(report)])
+        == 0
+    )
+
+    text = report.read_text(encoding="utf-8")
+    assert "Input Scan Report" in text
+    assert "note.md" in text
+
+
+def test_cli_list_adapters_includes_custom_rules(tmp_path: Path, capsys):
+    root = tmp_path / "content-os"
+    assert main(["init", "--root", str(root)]) == 0
+
+    assert main(["--root", str(root), "list-adapters"]) == 0
+
+    out = capsys.readouterr().out
+    assert "rule\tautoingest-cypher-note" in out
+    assert "built-in\tjson" in out

--- a/tests/test_content_os.py
+++ b/tests/test_content_os.py
@@ -1,0 +1,329 @@
+from pathlib import Path
+
+import pytest
+
+from content_os import core
+from content_os.models import ContentObject
+
+
+def make_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content-os"
+    core.init(root)
+    return root
+
+
+def test_init_creates_expected_structure(tmp_path):
+    root = make_root(tmp_path)
+    for rel in [
+        "strategy/positioning.md",
+        "voice/master-avoid-slop.md",
+        "stores/inbox.md",
+        "runs/active",
+        "modules/writer/SKILL.md",
+        "workflows/feedback-loop.md",
+        "config.yaml",
+    ]:
+        assert (root / rel).exists()
+
+
+def test_init_does_not_overwrite_files(tmp_path):
+    root = tmp_path / "content-os"
+    core.init(root)
+    target = root / "strategy" / "positioning.md"
+    target.write_text("custom", encoding="utf-8")
+    core.init(root)
+    assert target.read_text(encoding="utf-8") == "custom"
+
+
+def test_capture_can_append_to_inbox_without_run(tmp_path):
+    root = make_root(tmp_path)
+    path = core.capture(
+        root, "Inbox only", "raw note", None, "auto", create_run_folder=False
+    )
+    assert path is None
+    assert "Inbox only" in (root / "stores" / "inbox.md").read_text(encoding="utf-8")
+    assert not list((root / "runs" / "active").glob("2026-05-inbox-only*"))
+
+
+def test_research_route_feeds_candidate_ideas_store(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(
+        root, "Research ideas", text="research candidate ideas about onboarding"
+    )
+    core.route_run(root, path.name)
+    assert (root / "stores" / "ideas" / f"{path.name}.md").exists()
+
+
+def test_forced_failed_approval_requires_reason(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(root, "Fail without reason", "ORIGINAL")
+    (path / "draft-package.md").write_text("TODO groundbreaking", encoding="utf-8")
+    core.verify(root, path.name)
+    with pytest.raises(ValueError):
+        core.approve(root, path.name, force=True)
+
+
+def test_new_run_creates_valid_content_object(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(root, "A Test Idea", "ORIGINAL", "x_thread")
+    obj = core.load_object(path)
+    assert obj.title == "A Test Idea"
+    assert obj.state == "idea_review"
+    assert (path / "idea.md").exists()
+
+
+def test_state_transition_validation():
+    obj = ContentObject(id="x", title="X", slug="x")
+    obj.transition("brief_ready")
+    with pytest.raises(ValueError):
+        obj.transition("idea_review")
+
+
+def test_route_heuristic_behavior(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(
+        root, "Research ideas", text="research candidate ideas about onboarding"
+    )
+    reason = core.route_run(root, path.name)
+    assert core.load_object(path).route == "RESEARCH_IDEATE"
+    assert "Heuristic" in reason
+
+
+def test_brief_generation_includes_writer_context_packet_sections(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(root, "Brief me", "ORIGINAL")
+    core.make_brief(root, path.name)
+    text = (path / "brief.md").read_text(encoding="utf-8")
+    for section in [
+        "## thesis",
+        "## reader",
+        "## proof",
+        "## angle",
+        "## constraints",
+        "## voice anchors",
+        "## risks",
+        "## open loops",
+    ]:
+        assert section in text
+
+
+def test_verify_scorecard_calculates_correct_totals(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(root, "Score", "ORIGINAL")
+    (path / "draft-package.md").write_text(
+        "# Draft\n\nA checklist workflow template for a founder reader to apply without help. It uses proof, an example, screenshot visual, artifact, and metric.",
+        encoding="utf-8",
+    )
+    core.verify(root, path.name)
+    assert core.load_object(path).score == 12
+    assert "12/12" in (path / "verification.md").read_text(encoding="utf-8")
+
+
+def test_avoid_slop_catches_seeded_banned_phrases():
+    issues = core.avoid_slop(
+        "This is groundbreaking and experts believe it is a pivotal moment."
+    )
+    assert any("groundbreaking" in i for i in issues)
+    assert any("experts believe" in i for i in issues)
+
+
+def test_approve_refuses_failed_verification_unless_force(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(root, "Fail", "ORIGINAL")
+    (path / "draft-package.md").write_text("TODO groundbreaking", encoding="utf-8")
+    core.verify(root, path.name)
+    with pytest.raises(ValueError):
+        core.approve(root, path.name)
+    core.approve(root, path.name, force=True, reason="manual exception")
+    assert core.load_object(path).human_approved is True
+
+
+def test_scheduler_handoff_refuses_unapproved_runs(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(root, "No approval", "ORIGINAL")
+    with pytest.raises(ValueError):
+        core.scheduler_handoff(root, path.name, "x")
+
+
+def test_feedback_calculates_bookmark_rate_correctly(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(root, "Feedback", "ORIGINAL")
+    rates = core.feedback(
+        root, path.name, views=1000, bookmarks=50, likes=10, replies=5, reposts=5
+    )
+    assert rates["bookmark_rate"] == 0.05
+    assert (root / "stores" / "winners" / f"{path.name}.md").exists()
+
+
+def test_archive_moves_run_folder_correctly(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(root, "Archive", "ORIGINAL")
+    obj = core.load_object(path)
+    obj.state = "approved"
+    obj.human_approved = True
+    core.save_object(path, obj)
+    dest = core.archive(root, path.name)
+    assert dest.exists()
+    assert not path.exists()
+
+
+def test_doctor_detects_missing_files(tmp_path):
+    root = make_root(tmp_path)
+    (root / "voice" / "master-avoid-slop.md").unlink()
+    issues = core.doctor(root)
+    assert any("master-avoid-slop" in i for i in issues)
+
+
+def test_scan_inputs_detects_transcript_json(tmp_path):
+    root = make_root(tmp_path)
+    source = tmp_path / "segments.json"
+    source.write_text(
+        '{"title":"Interview","segments":[{"start":0,"text":"First lesson"},{"start":5,"text":"Second lesson"}]}',
+        encoding="utf-8",
+    )
+    docs, _ = core.scan_inputs(root, source)
+    assert docs[0].source_type == "transcript_json"
+    assert "First lesson" in docs[0].text
+
+
+def test_ingest_source_creates_proof_and_run(tmp_path):
+    root = make_root(tmp_path)
+    source = tmp_path / "summary.md"
+    source.write_text(
+        "# Summary\n\nA local autoingest lesson with reusable proof.", encoding="utf-8"
+    )
+    run_path, proof_path, source_doc = core.import_source(
+        root, source, title="Autoingest lesson"
+    )
+    assert source_doc.source_type == "summary"
+    assert proof_path is not None and proof_path.exists()
+    assert run_path is not None and (run_path / "content-object.yaml").exists()
+    obj = core.load_object(run_path)
+    assert obj.route == "REPURPOSE"
+    assert obj.attribution["source_path"] == str(source)
+
+
+def test_scan_inputs_writes_report(tmp_path):
+    root = make_root(tmp_path)
+    source = tmp_path / "note.txt"
+    source.write_text("plain text note", encoding="utf-8")
+    out = tmp_path / "scan.md"
+    docs, report_path = core.scan_inputs(root, tmp_path, out=out, limit=5)
+    assert docs
+    assert report_path == out
+    report = out.read_text(encoding="utf-8")
+    assert "Input Scan Report" in report
+    assert "Source ID" in report
+    assert "Adapter" in report
+
+
+def test_proof_path_for_source_does_not_overwrite_existing(tmp_path):
+    root = make_root(tmp_path)
+    from content_os.adapters import SourceDocument
+
+    doc = SourceDocument(
+        path=tmp_path / "note.md",
+        title="Same Proof",
+        source_type="text_note",
+        text="one",
+    )
+    first = core.proof_path_for_source(root, doc)
+    first.parent.mkdir(parents=True, exist_ok=True)
+    first.write_text("existing", encoding="utf-8")
+    second = core.proof_path_for_source(root, doc)
+    assert second != first
+    assert first.read_text(encoding="utf-8") == "existing"
+
+
+def test_scheduler_handoff_can_be_regenerated_after_scheduler_ready(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(root, "Ready again", "ORIGINAL")
+    (path / "draft-package.md").write_text(
+        "# Draft\n\nA checklist workflow template for a founder reader to apply without help. It uses proof, an example, screenshot visual, artifact, and metric.",
+        encoding="utf-8",
+    )
+    core.verify(root, path.name)
+    core.approve(root, path.name)
+    first = core.scheduler_handoff(root, path.name, "x")
+    second = core.scheduler_handoff(root, path.name, "linkedin")
+    assert first == second
+    assert "linkedin" in second.read_text(encoding="utf-8")
+
+
+def test_postiz_export_backs_up_existing_payload(tmp_path):
+    root = make_root(tmp_path)
+    path = core.create_run(root, "Export backup", "ORIGINAL")
+    obj = core.load_object(path)
+    obj.state = "approved"
+    obj.human_approved = True
+    core.save_object(path, obj)
+    (path / "draft-package.md").write_text("approved copy", encoding="utf-8")
+    out = tmp_path / "payload.json"
+    out.write_text("old", encoding="utf-8")
+    core.postiz_export(root, path.name, out)
+    assert out.with_suffix(".json.bak").read_text(encoding="utf-8") == "old"
+
+
+def test_init_writes_dynamic_source_adapter_rules(tmp_path):
+    root = make_root(tmp_path)
+    rules_path = root / "integrations" / "source-adapters.json"
+    assert rules_path.exists()
+    rules = core.load_adapter_rules(root)
+    assert any(rule.name == "autoingest-cypher-note" for rule in rules)
+
+
+def test_import_source_records_manifest_and_hash_attribution(tmp_path):
+    root = make_root(tmp_path)
+    source = tmp_path / "lesson.notejson"
+    source.write_text(
+        '{"title":"Lesson","body":"Dynamic source body"}', encoding="utf-8"
+    )
+
+    run_path, proof_path, source_doc = core.import_source(root, source)
+
+    assert run_path is not None
+    assert proof_path is not None
+    obj = core.load_object(run_path)
+    assert obj.attribution["source_id"] == source_doc.source_id
+    assert obj.attribution["sha256"] == source_doc.sha256
+    manifest = core.load_yaml(root / "stores" / "proof" / "source-manifest.json")
+    assert manifest["sources"][0]["source_id"] == source_doc.source_id
+
+
+def test_custom_rule_supports_autoingest_cypher_files(tmp_path):
+    root = make_root(tmp_path)
+    source = tmp_path / "location.cy"
+    source.write_text("MATCH (n) RETURN n LIMIT 5", encoding="utf-8")
+
+    docs, _ = core.scan_inputs(root, source)
+
+    assert docs[0].adapter == "rule:autoingest-cypher-note"
+    assert docs[0].source_type == "graph_query_note"
+    assert docs[0].suggested_route == "RESEARCH_IDEATE"
+
+
+def test_doctor_reports_invalid_adapter_registry(tmp_path):
+    root = make_root(tmp_path)
+    (root / "integrations" / "source-adapters.json").write_text(
+        '[{"name":"bad","extensions":["notejson"],"source_type":"bad","route":"SPAM"}]',
+        encoding="utf-8",
+    )
+
+    issues = core.doctor(root)
+
+    assert any("invalid extensions" in issue for issue in issues)
+    assert any("invalid route" in issue for issue in issues)
+
+
+def test_malformed_adapter_registry_does_not_break_builtin_scan(tmp_path):
+    root = make_root(tmp_path)
+    (root / "integrations" / "source-adapters.json").write_text(
+        "{not-json", encoding="utf-8"
+    )
+    source = tmp_path / "note.txt"
+    source.write_text("still works", encoding="utf-8")
+
+    docs, _ = core.scan_inputs(root, source)
+
+    assert docs[0].source_type == "text_note"
+    assert any("Malformed adapter registry" in issue for issue in core.doctor(root))


### PR DESCRIPTION
### Motivation

- Provide a local-first, approval-gated content workflow that captures, routes, briefs, drafts, verifies, and handoffs content without auto-publishing.
- Support safe autoingest of user-owned local inputs (transcripts, JSON/CSV, PDFs, media manifests) with declarative adapter rules and explicit proof recording.
- Make LLM-assisted drafting optional via OpenAI-compatible env vars while keeping deterministic placeholder behavior when not configured.

### Description

- Add a CLI entrypoint (`content_os.cli`) and command mapping for `init`, `capture`, `new-run`, `brief`, `draft`, `verify`, `approve`, `scheduler-handoff`, `postiz-export`, `scan-inputs`, `ingest-source`, `list-adapters`, `status`, and `doctor`.
- Implement core workflow engine in `content_os.core` including run creation, routing heuristics, brief/draft/verify/approve/scheduler flows, payload generation, feedback handling, and `doctor` checks.
- Add input adapters in `content_os.adapters` with built-in handlers for JSON/JSONL, CSV, text/subtitle, PDF (optional `pypdf`), and media manifests, plus declarative `AdapterRule` support and SHA-256 source manifest recording.
- Provide file utilities in `content_os.io`, content models and state machine in `content_os.models`, package metadata (`pyproject.toml`), documentation (`README.md`, `docs/architecture.md`), examples, `.env.example`, and `.gitignore`.

### Testing

- Added comprehensive unit tests under `tests/` covering adapters, CLI flows, core behaviors, state transitions, scanning/ingest, verification rules, approval and handoff; tests include `tests/test_adapters.py`, `tests/test_cli.py`, and `tests/test_content_os.py`.
- Ran `pytest` against the `tests/` suite and confirmed all tests passed successfully.
- CLI smoke paths exercised in tests include `init`, `capture --no-run`, `ingest-source`, `scan-inputs`, `list-adapters`, `status`, `verify`, and `approve` failure/force behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0257f6076c83258fe3f2e65110e47d)