### PR TITLE
Handle flexible recorder media imports

### DIFF
--- a/audio_copy.sh
+++ b/audio_copy.sh
@@ -10,7 +10,7 @@ LOG_PREFIX="[audio_copy]"
 # ======================
 
 # What gets copied:
-# 1) Audio: *.wav, *.mp3 (case-insensitive)
+# 1) Audio/video: common recorder media (*.wav, *.mp3, *.mp4, *.m4a, etc.; case-insensitive)
 # 2) Audio sidecars (same folder as the audio), e.g.:
 #    <basename>.*            (e.g., 20250823030047.WAV.music.json)
 #    <stem>.{json,cue,md5,sha1,sha256,yaml,yml,ini,xml,info,tag}
@@ -29,7 +29,7 @@ LOG_PREFIX="[audio_copy]"
 
 echo "$LOG_PREFIX Starting…"
 
-shopt -s nullglob dotglob nocaseglob
+shopt -s nullglob dotglob nocaseglob nocasematch
 
 # -------- Helpers --------
 copy_one() {
@@ -77,11 +77,42 @@ copy_audio_sidecars() {
       continue
     fi
     # Don't accidentally grab other audio files
-    if [[ "$c" =~ \.(wav|mp3)$ ]]; then
+    if [[ "$c" =~ \.(3gp|aac|aiff|amr|avi|flac|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpg|oga|ogg|opus|wav|webm|wma)$ ]]; then
       continue
     fi
     copy_one "$c" "$dest_dir" || true
   done
+}
+
+
+parse_media_date() {
+  local bname="$1"
+  python3 - "$bname" <<'PY'
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+stem = Path(sys.argv[1]).stem
+patterns = [
+    re.compile(r"(?<!\d)(?:[A-Za-z]{1,8})?(?P<year>(?:19|20)\d{2})[_-]?(?P<month>\d{2})(?P<day>\d{2})[_-]?(?P<hour>\d{2})(?P<minute>\d{2})(?P<second>\d{2})(?!\d)"),
+    re.compile(r"(?<!\d)(?:[A-Za-z]{1,8}[_-]?)?(?P<year>(?:19|20)\d{2})[_-](?P<month>\d{2})[_-](?P<day>\d{2})[ T_-]+(?P<hour>\d{2})[:._-]?(?P<minute>\d{2})[:._-]?(?P<second>\d{2})(?!\d)"),
+    re.compile(r"(?<!\d)(?:[A-Za-z]{1,8}[_-]?)?(?P<year>(?:19|20)\d{2})[_-](?P<month>\d{2})[_-](?P<day>\d{2})(?!\d)"),
+]
+for pattern in patterns:
+    for match in pattern.finditer(stem):
+        parts = match.groupdict()
+        try:
+            dt = datetime(
+                int(parts["year"]), int(parts["month"]), int(parts["day"]),
+                int(parts.get("hour") or 0), int(parts.get("minute") or 0), int(parts.get("second") or 0),
+            )
+        except ValueError:
+            continue
+        print(dt.strftime("%Y%m%d%H%M%S %Y %m %d"))
+        sys.exit(0)
+sys.exit(1)
+PY
 }
 
 # Find & copy transcripts/diarization anywhere under SRC_BASE that match the stamp
@@ -144,20 +175,17 @@ for MOUNTPOINT in "${CANDIDATES[@]}"; do
   [[ -d "$SRC_BASE" ]] || continue
   echo "$LOG_PREFIX 📂 Found source directory: $SRC_BASE"
 
-  # Find WAV/MP3 (case-insensitive), recursively, space-safe
+  # Find recorder media (case-insensitive), recursively, space-safe
   while IFS= read -r -d '' file; do
     bname="$(basename "$file")"
 
-    # Parse 14-digit stamp from filename if present: YYYYMMDDhhmmss.ext
+    # Parse a recorder timestamp from filename when present (e.g. R2025_0911_223045.mp3,
+    # 20250911223045.WAV, REC_2025-09-11_22-30-45.m4a); otherwise use mtime.
     stamp=""
     year=""; month=""; day=""
-    if [[ "$bname" =~ ^([0-9]{14})\.(wav|mp3)$ ]]; then
-      stamp="${BASH_REMATCH[1]}"
-      year="${stamp:0:4}"
-      month="${stamp:4:2}"
-      day="${stamp:6:2}"
+    if parsed_date=$(parse_media_date "$bname" 2>/dev/null); then
+      read -r stamp year month day <<< "$parsed_date"
     else
-      # Fallback to file modified date
       mod_date="$(stat -c %y "$file" 2>/dev/null | cut -d' ' -f1 || true)"
       if [[ "$mod_date" =~ ^([0-9]{4})-([0-9]{2})-([0-9]{2})$ ]]; then
         year="${BASH_REMATCH[1]}"; month="${BASH_REMATCH[2]}"; day="${BASH_REMATCH[3]}"
@@ -184,7 +212,7 @@ for MOUNTPOINT in "${CANDIDATES[@]}"; do
       copy_transcripts_by_stamp "$SRC_BASE" "$stamp" "$year" "$month" "$day" || true
     fi
 
-  done < <(find "$SRC_BASE" -type f \( -iname "*.wav" -o -iname "*.mp3" \) -print0)
+  done < <(find "$SRC_BASE" -type f \( -iname "*.3gp" -o -iname "*.aac" -o -iname "*.aiff" -o -iname "*.amr" -o -iname "*.avi" -o -iname "*.flac" -o -iname "*.m4a" -o -iname "*.m4v" -o -iname "*.mkv" -o -iname "*.mov" -o -iname "*.mp3" -o -iname "*.mp4" -o -iname "*.mpeg" -o -iname "*.mpg" -o -iname "*.oga" -o -iname "*.ogg" -o -iname "*.opus" -o -iname "*.wav" -o -iname "*.webm" -o -iname "*.wma" \) -print0)
 
 done
 

--- a/load_files.sh
+++ b/load_files.sh
@@ -1,70 +1,134 @@
 #!/bin/bash
+set -euo pipefail
+shopt -s nocasematch
 
-# Function to check if all files in input directories are accounted for in the output directory
-validate_files() {
-    for file in "${all_files[@]}"; do
-        filename=$(basename "$file")
-        IFS='_' read -r -a parts <<< "$filename"
-        year="${parts[0]}"
-        month="${parts[1]:0:2}"
-        day="${parts[1]:2:2}"
+# Organize common media files from one or more source directories into:
+#   <output_base_path>/YYYY/MM/DD/<original_filename>
+#
+# Timestamp parsing is intentionally flexible for recorder/camera filenames such as:
+#   2025_0911_223045_F.MP4
+#   20250911223045.WAV
+#   R2025_0911_223045.mp3
+#   REC_2025-09-11_22-30-45.m4a
+# If no valid timestamp is found in the name, the file modified date is used.
 
-        dest_dir="$output_base_path/$year/$month/$day"
-        dest_file="$dest_dir/$filename"
+MEDIA_EXT_REGEX='\.(3gp|aac|aiff|amr|avi|flac|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpg|oga|ogg|opus|wav|webm|wma)$'
 
-        if [ ! -f "$dest_file" ]; then
-            echo "File $filename is missing in the output directory."
-            return 1
-        fi
-    done
-    echo "All files are accounted for in the output directory."
-    return 0
+usage() {
+  echo "Usage: $0 <output_base_path> <source_dir1> <source_dir2> ... <source_dirN>"
 }
 
-# Check if at least two arguments are provided
+parse_date_from_name() {
+  local filename="$1"
+  local parsed
+
+  parsed=$(python3 - "$filename" <<'PY'
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+stem = Path(sys.argv[1]).stem
+patterns = [
+    re.compile(r"(?<!\d)(?:[A-Za-z]{1,8})?(?P<year>(?:19|20)\d{2})[_-]?(?P<month>\d{2})(?P<day>\d{2})[_-]?(?P<hour>\d{2})(?P<minute>\d{2})(?P<second>\d{2})(?!\d)"),
+    re.compile(r"(?<!\d)(?:[A-Za-z]{1,8}[_-]?)?(?P<year>(?:19|20)\d{2})[_-](?P<month>\d{2})[_-](?P<day>\d{2})[ T_-]+(?P<hour>\d{2})[:._-]?(?P<minute>\d{2})[:._-]?(?P<second>\d{2})(?!\d)"),
+    re.compile(r"(?<!\d)(?:[A-Za-z]{1,8}[_-]?)?(?P<year>(?:19|20)\d{2})[_-](?P<month>\d{2})[_-](?P<day>\d{2})(?!\d)"),
+]
+for pattern in patterns:
+    for match in pattern.finditer(stem):
+        parts = match.groupdict()
+        try:
+            dt = datetime(
+                int(parts["year"]), int(parts["month"]), int(parts["day"]),
+                int(parts.get("hour") or 0), int(parts.get("minute") or 0), int(parts.get("second") or 0),
+            )
+        except ValueError:
+            continue
+        print(dt.strftime("%Y/%m/%d"))
+        sys.exit(0)
+sys.exit(1)
+PY
+  ) && printf '%s' "$parsed"
+}
+
+file_date_path() {
+  local file="$1"
+  local filename date_path
+  filename=$(basename "$file")
+
+  if date_path=$(parse_date_from_name "$filename"); then
+    printf '%s' "$date_path"
+    return 0
+  fi
+
+  # Fallback to mtime when filename is not parseable.
+  if date -r "$file" '+%Y/%m/%d' >/dev/null 2>&1; then
+    date -r "$file" '+%Y/%m/%d'
+  else
+    stat -c '%y' "$file" | cut -d' ' -f1 | tr '-' '/'
+  fi
+}
+
+validate_files() {
+  local missing=0 file filename date_path dest_file
+  for file in "${all_files[@]}"; do
+    filename=$(basename "$file")
+    if [[ ! "$filename" =~ $MEDIA_EXT_REGEX ]]; then
+      continue
+    fi
+    date_path=$(file_date_path "$file")
+    dest_file="$output_base_path/$date_path/$filename"
+
+    if [ ! -f "$dest_file" ]; then
+      echo "File $filename is missing in the output directory: $dest_file"
+      missing=1
+    fi
+  done
+
+  if [ "$missing" -eq 0 ]; then
+    echo "All files are accounted for in the output directory."
+    return 0
+  fi
+  return 1
+}
+
 if [ "$#" -lt 2 ]; then
-    echo "Usage: $0 <output_base_path> <source_dir1> <source_dir2> ... <source_dirN>"
-    exit 1
+  usage
+  exit 1
 fi
 
 output_base_path="$1"
-shift  # Remove the first argument, leaving only source directories
+shift
 
-# Collect all files from the multiple input directories
 all_files=()
 for source_dir in "$@"; do
-    if [ ! -d "$source_dir" ]; then
-        echo "Source directory $source_dir does not exist."
-        exit 1
-    fi
+  if [ ! -d "$source_dir" ]; then
+    echo "Source directory $source_dir does not exist."
+    exit 1
+  fi
 
-    for file in "$source_dir"/*; do
-        if [ -f "$file" ]; then
-            all_files+=("$file")
-        fi
-    done
+  while IFS= read -r -d '' file; do
+    all_files+=("$file")
+  done < <(find "$source_dir" -maxdepth 1 -type f -print0)
 done
 
-# Loop through each collected file
 for file in "${all_files[@]}"; do
-    if [ -f "$file" ]; then
-        # Extract year, month, and day from the filename
-        filename=$(basename "$file")
-        IFS='_' read -r -a parts <<< "$filename"
-        year="${parts[0]}"
-        month="${parts[1]:0:2}"
-        day="${parts[1]:2:2}"
+  filename=$(basename "$file")
+  if [[ ! "$filename" =~ $MEDIA_EXT_REGEX ]]; then
+    echo "Skipping non-media file: $file"
+    continue
+  fi
 
-        # Create directory structure if it doesn't exist in the output base path
-        dest_dir="$output_base_path/$year/$month/$day"
-        mkdir -p "$dest_dir"
+  date_path=$(file_date_path "$file")
+  dest_dir="$output_base_path/$date_path"
+  mkdir -p "$dest_dir"
 
-        # Copy the file to the appropriate directory in the output base path
-        cp "$file" "$dest_dir"
-        echo "Copied $file to $dest_dir"
-    fi
+  if [ -e "$dest_dir/$filename" ]; then
+    echo "Exists, skipping: $dest_dir/$filename"
+  else
+    cp -- "$file" "$dest_dir/"
+    echo "Copied $file to $dest_dir"
+  fi
 done
 
-# Validate that all files are accounted for in the output directory
 validate_files
-

--- a/move_files.py
+++ b/move_files.py
@@ -1,22 +1,18 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Organize files named `YYYY_MMDD_HHMMSS_{tail}` into `YYYY/MM/DD/<original_name>`.
+Organize media files into `YYYY/MM/DD/<original_name>` folders.
 
-Examples:
-  python organize_by_timestamp.py -i /audio -o /archive
-  python organize_by_timestamp.py -i /audio -o /archive --dry-run --recursive
-  python organize_by_timestamp.py -i /audio -o /archive --strategy rename --max-workers 8
+The timestamp parser is intentionally permissive so files from different
+recorders/cameras can be mixed in one import pass. Supported filename examples:
 
-File name format assumed at START of basename:
-  YYYY_MMDD_HHMMSS_{tail}[.ext]
-Where:
-  - YYYY: year (4 digits)
-  - MMDD: month (01-12) + day (01-31)
-  - HHMMSS: 24h time
-  - {tail}: anything (may contain underscores, dots, etc.)
+  2025_0911_223045_F.MP4
+  20250911223045.WAV
+  R2025_0911_223045.mp3
+  REC_2025-09-11_22-30-45.m4a
 
-Non-matching or invalid-date filenames are skipped (with a warning).
+By default only common audio/video files are moved. Files with no recognizable
+filename timestamp can optionally be placed by filesystem modified time.
 """
 # python move_files.py -i /mnt/8TB_2025/fileserver/audio -o /mnt/8TB_2025/fileserver/audio --dry-run --recursive
 from __future__ import annotations
@@ -32,14 +28,45 @@ import re
 import shutil
 import sys
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Iterable, Optional
 
 
-NAME_PATTERN = re.compile(
-    r'^(?P<ts>(?:\d{4}_\d{4}_\d{6}|\d{14}))(?:[_.].*)?$'
+DEFAULT_MEDIA_EXTENSIONS = {
+    ".3gp", ".aac", ".aiff", ".amr", ".avi", ".flac", ".m4a", ".m4v",
+    ".mkv", ".mov", ".mp3", ".mp4", ".mpeg", ".mpg", ".oga", ".ogg",
+    ".opus", ".wav", ".webm", ".wma",
+}
+
+# Look for timestamps anywhere in the filename stem. Several voice recorders
+# prefix the timestamp with a channel/source letter (for example R2025_...).
+TIMESTAMP_PATTERNS = (
+    # YYYY_MMDD_HHMMSS, RYYYY_MMDD_HHMMSS, YYYYMMDDHHMMSS
+    re.compile(
+        r"(?<!\d)(?:[A-Za-z]{1,8})?"
+        r"(?P<year>(?:19|20)\d{2})[_-]?"
+        r"(?P<month>\d{2})(?P<day>\d{2})[_-]?"
+        r"(?P<hour>\d{2})(?P<minute>\d{2})(?P<second>\d{2})(?!\d)"
+    ),
+    # YYYY-MM-DD_HH-MM-SS, YYYY_MM_DD HH.MM.SS, etc.
+    re.compile(
+        r"(?<!\d)(?:[A-Za-z]{1,8}[_-]?)?"
+        r"(?P<year>(?:19|20)\d{2})[_-]"
+        r"(?P<month>\d{2})[_-]"
+        r"(?P<day>\d{2})[ T_-]+"
+        r"(?P<hour>\d{2})[:._-]?"
+        r"(?P<minute>\d{2})[:._-]?"
+        r"(?P<second>\d{2})(?!\d)"
+    ),
+    # YYYY-MM-DD or YYYY_MM_DD when the recorder omits time from the name.
+    re.compile(
+        r"(?<!\d)(?:[A-Za-z]{1,8}[_-]?)?"
+        r"(?P<year>(?:19|20)\d{2})[_-]"
+        r"(?P<month>\d{2})[_-]"
+        r"(?P<day>\d{2})(?!\d)"
+    ),
 )
 
-@dataclass
+@dataclass(frozen=True)
 class ParsedName:
     year: int
     month: int
@@ -49,39 +76,76 @@ class ParsedName:
     second: int
     ts_compact: str        # e.g. 20250911223045
     ts_underscored: str    # e.g. 2025_0911_223045
+    source: str            # filename or mtime
 
-def parse_name(basename: str) -> Optional[ParsedName]:
-    m = NAME_PATTERN.match(basename)
-    if not m:
+
+def _parsed_from_parts(parts: dict[str, str], source: str) -> Optional[ParsedName]:
+    year = int(parts["year"])
+    month = int(parts["month"])
+    day = int(parts["day"])
+    hour = int(parts.get("hour") or 0)
+    minute = int(parts.get("minute") or 0)
+    second = int(parts.get("second") or 0)
+
+    try:
+        dt = datetime(year, month, day, hour, minute, second)
+    except ValueError:
         return None
 
-    ts = m.group('ts')
-    if '_' in ts:
-        # YYYY_MMDD_HHMMSS
-        year  = ts[0:4]
-        month = ts[5:7]
-        day   = ts[7:9]
-        hour  = ts[10:12]
-        minute= ts[12:14]
-        second= ts[14:16]
-    else:
-        # YYYYMMDDHHMMSS
-        year  = ts[0:4]
-        month = ts[4:6]
-        day   = ts[6:8]
-        hour  = ts[8:10]
-        minute= ts[10:12]
-        second= ts[12:14]
-
-    # Build normalized forms
-    ts_compact = f"{year}{month}{day}{hour}{minute}{second}"
-    ts_underscored = f"{year}_{month}{day}_{hour}{minute}{second}"
-
+    ts_compact = dt.strftime("%Y%m%d%H%M%S")
+    ts_underscored = dt.strftime("%Y_%m%d_%H%M%S")
     return ParsedName(
-        year=int(year), month=int(month), day=int(day),
-        hour=int(hour), minute=int(minute), second=int(second),
-        ts_compact=ts_compact, ts_underscored=ts_underscored
+        year=dt.year,
+        month=dt.month,
+        day=dt.day,
+        hour=dt.hour,
+        minute=dt.minute,
+        second=dt.second,
+        ts_compact=ts_compact,
+        ts_underscored=ts_underscored,
+        source=source,
     )
+
+
+def parse_name(basename: str) -> Optional[ParsedName]:
+    """Parse a date/time from a recorder filename without assuming one layout."""
+    stem = Path(basename).stem
+    for pattern in TIMESTAMP_PATTERNS:
+        for match in pattern.finditer(stem):
+            parsed = _parsed_from_parts(match.groupdict(), source="filename")
+            if parsed:
+                return parsed
+    return None
+
+
+def parse_mtime(path: Path) -> Optional[ParsedName]:
+    try:
+        dt = datetime.fromtimestamp(path.stat().st_mtime)
+    except OSError:
+        return None
+    return ParsedName(
+        year=dt.year,
+        month=dt.month,
+        day=dt.day,
+        hour=dt.hour,
+        minute=dt.minute,
+        second=dt.second,
+        ts_compact=dt.strftime("%Y%m%d%H%M%S"),
+        ts_underscored=dt.strftime("%Y_%m%d_%H%M%S"),
+        source="mtime",
+    )
+
+
+def normalize_extensions(raw: str) -> Optional[set[str]]:
+    if raw.lower() == "all":
+        return None
+    exts: set[str] = set()
+    for item in raw.split(","):
+        item = item.strip().lower()
+        if not item:
+            continue
+        exts.add(item if item.startswith(".") else f".{item}")
+    return exts
 
 
 def compute_hash(path: Path, algo: str = "md5", chunk_size: int = 1024 * 1024) -> str:
@@ -102,11 +166,9 @@ def choose_collision_action(
     Returns the finalized destination Path, or None if we should skip.
     NOTE: dst must be a FILE path (not a directory).
     """
-    # If somehow caller passed a directory, place file inside it
     if dst.exists() and dst.is_dir():
         dst = dst / src.name
 
-    # If the exact same path, nothing to do
     try:
         if src.resolve() == dst.resolve():
             logging.info("Skip (same path): %s", src)
@@ -118,7 +180,6 @@ def choose_collision_action(
         return dst
 
     if strategy == "skip":
-        # Consider it the same if sizes match; optionally confirm by hash
         same = False
         try:
             if src.stat().st_size == dst.stat().st_size:
@@ -141,7 +202,6 @@ def choose_collision_action(
         raise FileExistsError(f"Destination exists: {dst}")
 
     if strategy == "rename":
-        # Append suffix _1, _2, ... before extension
         parent = dst.parent
         stem = dst.stem
         suffix = dst.suffix
@@ -154,16 +214,13 @@ def choose_collision_action(
 
     raise ValueError(f"Unknown strategy: {strategy}")
 
-def build_destination(root_out: Path, basename: str) -> Optional[Path]:
+def build_destination(root_out: Path, basename: str, parsed: ParsedName) -> Path:
     """
     Return the FULL destination file path:
       <root_out>/YYYY/MM/DD/<basename>
     """
-    parsed = parse_name(basename)
-    if not parsed:
-        return None
     subdir = Path(f"{parsed.year:04d}") / f"{parsed.month:02d}" / f"{parsed.day:02d}"
-    return (root_out / subdir / basename)
+    return root_out / subdir / basename
 
 def move_one(
     src: Path,
@@ -171,33 +228,44 @@ def move_one(
     dry_run: bool,
     strategy: str,
     hash_algo: Optional[str],
+    date_source: str,
 ) -> str:
     basename = src.name
-    dst = build_destination(root_out, basename)
-    if dst is None:
-        logging.warning("Name does not match pattern, skipping: %s", src)
+    parsed = parse_name(basename)
+    if parsed is None and date_source == "mtime-fallback":
+        parsed = parse_mtime(src)
+
+    if parsed is None:
+        logging.warning("No usable date in filename, skipping: %s", src)
         return "skipped"
 
-    # Ensure parent directory exists before collision decision where needed
+    dst = build_destination(root_out, basename, parsed)
+
     final_dst = choose_collision_action(src, dst, strategy=strategy, hash_algo=hash_algo)
     if final_dst is None:
         return "skipped"
 
     if dry_run:
-        logging.info("[DRY-RUN] Would move: %s -> %s", src, final_dst)
+        logging.info("[DRY-RUN] Would move (%s date): %s -> %s", parsed.source, src, final_dst)
         return "dry"
 
     final_dst.parent.mkdir(parents=True, exist_ok=True)
 
     try:
         shutil.move(str(src), str(final_dst))
-        logging.info("Moved: %s -> %s", src, final_dst)
+        logging.info("Moved (%s date): %s -> %s", parsed.source, src, final_dst)
         return "moved"
     except Exception as e:
         logging.error("Failed moving %s -> %s: %s", src, final_dst, e)
         return "error"
 
-def iter_files(root_in: Path, recursive: bool, include_hidden: bool, follow_symlinks: bool):
+def iter_files(
+    root_in: Path,
+    recursive: bool,
+    include_hidden: bool,
+    follow_symlinks: bool,
+    allowed_extensions: Optional[set[str]],
+) -> Iterable[Path]:
     if recursive:
         it = root_in.rglob("*")
     else:
@@ -211,14 +279,15 @@ def iter_files(root_in: Path, recursive: bool, include_hidden: bool, follow_syml
                 continue
             if not include_hidden and p.name.startswith("."):
                 continue
+            if allowed_extensions is not None and p.suffix.lower() not in allowed_extensions:
+                continue
             yield p
         except OSError:
-            # Permissions races, broken symlinks, etc.
             continue
 
 def main():
     ap = argparse.ArgumentParser(
-        description="Move files named 'YYYY_MMDD_HHMMSS_{tail}' into YYYY/MM/DD/ subfolders."
+        description="Move media files into YYYY/MM/DD/ subfolders using flexible recorder timestamps."
     )
     ap.add_argument("-i", "--input", required=True, type=Path, help="Input directory to scan")
     ap.add_argument("-o", "--output", required=True, type=Path, help="Output directory root")
@@ -226,6 +295,17 @@ def main():
     ap.add_argument("--follow-symlinks", action="store_true", help="Follow symlinked files")
     ap.add_argument("--include-hidden", action="store_true", help="Include dotfiles")
     ap.add_argument("--dry-run", "-n", action="store_true", help="Show actions without moving")
+    ap.add_argument(
+        "--extensions",
+        default=",".join(sorted(DEFAULT_MEDIA_EXTENSIONS)),
+        help="Comma-separated extensions to process, or 'all' (default: common audio/video)",
+    )
+    ap.add_argument(
+        "--date-source",
+        choices=["filename", "mtime-fallback"],
+        default="mtime-fallback",
+        help="Use only filename dates or fall back to file modified time (default: mtime-fallback)",
+    )
     ap.add_argument(
         "--strategy",
         choices=["skip", "rename", "overwrite", "fail"],
@@ -261,19 +341,19 @@ def main():
         logging.error("Input is not a directory: %s", args.input)
         sys.exit(2)
 
+    allowed_extensions = normalize_extensions(args.extensions)
     args.output.mkdir(parents=True, exist_ok=True)
 
-    files = list(iter_files(args.input, args.recursive, args.include_hidden, args.follow_symlinks))
+    files = list(iter_files(args.input, args.recursive, args.include_hidden, args.follow_symlinks, allowed_extensions))
     if not files:
-        logging.warning("No files found in input (check flags).")
+        logging.warning("No matching files found in input (check flags/extensions).")
         return
 
     logging.info("Discovered %d file(s) to consider.", len(files))
 
     counts = {"moved": 0, "skipped": 0, "dry": 0, "error": 0}
-    work = [(p, args.output, args.dry_run, args.strategy, args.hash) for p in files]
+    work = [(p, args.output, args.dry_run, args.strategy, args.hash, args.date_source) for p in files]
 
-    # Threaded I/O: safe for shutil + filesystem ops
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.max_workers) as ex:
         futures = [ex.submit(move_one, *w) for w in work]
         for fut in concurrent.futures.as_completed(futures):


### PR DESCRIPTION
### Motivation
- Existing import/movement scripts assumed a strict `YYYY_MMDD_HHMMSS` or 14-digit stamp in filenames which fails for some voice recorders that prefix or vary their timestamp format. The goal is to robustly detect recorder timestamps and route common media (MP4/MP3/WAV/M4A/MOV/etc.) into `YYYY/MM/DD` folders.

### Description
- Broadened filename timestamp parsing in `move_files.py` to accept compact 14-digit stamps, underscored timestamps, prefixed recorder names (e.g. `R2025_0911_223045`), separated date/time layouts, and a configurable fallback to filesystem mtime; added the `--date-source` option to control fallback behavior and a permissive `TIMESTAMP_PATTERNS` parser. 
- Added media-extension filtering and `--extensions` support in `move_files.py` via `DEFAULT_MEDIA_EXTENSIONS` and `normalize_extensions` so only recorder media are considered by default. 
- Reworked `load_files.sh` to skip non-media files, use an embedded Python-based `parse_date_from_name` for flexible timestamp extraction, fall back to file mtime when necessary, and copy media into `<output>/YYYY/MM/DD/`. 
- Updated `audio_copy.sh` to scan a broader set of recorder media extensions, added a `parse_media_date` helper (Python inline) to extract timestamps from varied recorder filename formats, preserved sidecar/transcript-copying behavior when a timestamp is found, and ensured case-insensitive matching via `shopt -s nocasematch`.

### Testing
- Ran Python static check: `python3 -m py_compile move_files.py` and it succeeded. 
- Performed shell syntax checks: `bash -n load_files.sh` and `bash -n audio_copy.sh` with no syntax errors. 
- Executed an end-to-end smoke test using temporary files which ran `move_files.py` in `--dry-run` and then `load_files.sh` to copy files, verifying that test files like `R2025_0911_223045.mp3` and `REC_2025-09-12_01-02-03.MP4` were routed to `YYYY/MM/DD` paths; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0366f116c48325a26ace2d76648e97)