### PR TITLE
Add containerized deployment, cron schedules, and NAS-based distributed ingest tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates tzdata cron \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md /app/
+COPY content_os /app/content_os
+COPY requirements.txt /app/requirements.txt
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -e . \
+    && if [ -s /app/requirements.txt ]; then pip install --no-cache-dir -r /app/requirements.txt; fi
+
+COPY . /app
+
+ENTRYPOINT ["python"]
+CMD ["-m", "content_os", "--help"]

--- a/README.md
+++ b/README.md
@@ -103,3 +103,101 @@ Supported local input families include Markdown/text notes, transcript exports (
 Dynamic source rules live in `content-os/integrations/source-adapters.json`. Add a rule there to support a new extension or JSON shape without changing Python code, then run `content-os list-adapters` to confirm the rule is active. `content-os doctor` validates the adapter registry and reports malformed JSON, invalid extensions, invalid routes, and invalid formats. Ingested sources are tracked by SHA-256 in `stores/proof/source-manifest.json` so proof can be traced back to local inputs.
 
 `RESEARCH_IDEATE` routes write candidate material into `stores/ideas/` so research scans do not become publishable drafts without a separate human-reviewed run.
+
+## Containerization and scheduled jobs
+
+This repo can run as independent microservice-style containers for ingestion and content workflow orchestration, including distributed workers sharing a NAS drop location.
+
+### Build once
+
+```bash
+docker compose build
+```
+
+### Run long-running service containers
+
+```bash
+docker compose up -d ingest-service ingest-worker content-service
+```
+
+- `ingest-service` runs `run_ingest_all.sh`. That script already has a lock (`/tmp/ingest_transcripts.lock`) and is safe to trigger repeatedly without overlapping work.
+- `ingest-worker` processes claimed job files from a NAS drop point (`/nas/drop/*.job`) so multiple machines can collaborate on heavy batch workloads.
+- `content-service` runs the Content OS CLI entrypoint (example command: `content-os status`) and can be adapted to batch workflows (`brief`, `draft`, `verify`, etc.).
+
+### Run cron/batch containers
+
+```bash
+docker compose up -d ingest-cron content-cron
+```
+
+- `ingest-cron` runs every 5 minutes and relies on the ingest lock to avoid duplicate simultaneous runs.
+- `content-cron` runs every 30 minutes for periodic content workflow jobs.
+
+### Distributed worker pattern (NAS drop)
+
+Each worker host can run `ingest-worker` against the same NAS mount. Place executable `.job` files in `${DROP_ROOT}` (default `/nas/drop`). Workers atomically claim files by renaming into `/nas/drop/claimed`, then move to `/nas/drop/done` or `/nas/drop/failed`.
+
+Example job file (`/nas/drop/2026-05-20-batch-001.job`):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd /app
+/usr/bin/env bash run_ingest_all.sh
+```
+
+
+### Data-endpoint strategy (S drive + NAS1 + shared NAS mount)
+
+Because your pipeline now spans mixed storage generations, configure by **data family** instead of one flat root:
+
+- **Audio-first target**: point `AUDIO_ROOT` to `/nas/S/audio` as S-drive ingestion becomes canonical.
+- **Legacy video/metadata**: keep dashcam/bodycam/transcript paths on NAS1-style directories until migrated.
+- **Shared worker drop queue**: keep `DROP_ROOT` on the shared NAS mount so every worker host can claim jobs atomically.
+- **Neo4j migration-safe**: always set `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `NEO4J_DB` explicitly in `.env`.
+
+A starter env template is included at `deploy/path_profiles.env.example`.
+
+### Creating data-type specific distributed jobs
+
+Use the helper to enqueue work by data family:
+
+```bash
+# create audio-only job
+DROP_ROOT=/nas/drop ./deploy/create_job.sh audio
+
+# create dashcam-only job
+DROP_ROOT=/nas/drop ./deploy/create_job.sh dashcam
+
+# create bodycam-only job
+DROP_ROOT=/nas/drop ./deploy/create_job.sh bodycam
+```
+
+This lets different machines specialize throughput (for example, audio/transcription vs. video-heavy passes) while sharing the same claim/done/failed workflow.
+
+### NAS and environment configuration
+
+The compose file mounts `${NAS_ROOT}` (default `/media/scott/NAS`) into containers at `/nas` and provides `SCAN_ROOTS` / `DASHCAM_ROOT` defaults based on that mount. Override with a `.env` file for each machine.
+
+### Notes
+
+- Keep sensitive environment variables in a `.env` file and reference them from `docker-compose.yml`.
+- Update cron commands and job payload scripts to match your final ingestion/content pipeline.
+
+
+## Deployment runbook
+
+For a full file-by-file deployment and operations guide, see [`docs/deployment_runbook.md`](docs/deployment_runbook.md).
+
+
+## x1-370 and deathstar-XPS-8920 migration notes
+
+Operational model:
+- `deathstar-XPS-8920` is treated as a **legacy producer** that drops files into the shared fileserver path.
+- `x1-370` is the **active processing host** that syncs, normalizes, and ingests data into current pipelines.
+
+Current defaults assume NAS1 on x1-370:
+- `NAS_ROOT=/media/scott/NAS1` mounted to `/nas` in containers.
+- Legacy incoming drop path: `/nas/fileserver/incoming/deathstar`.
+
+Use `deploy/sync_from_legacy_drop.sh` to copy legacy drops into canonical roots, including transcripts, YOLO outputs, and metadata CSV/JSON files before ingest runs.

--- a/deploy/create_job.sh
+++ b/deploy/create_job.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DROP_ROOT="${DROP_ROOT:-/nas/drop}"
+JOB_KIND="${1:-all}"
+STAMP="$(date +%Y%m%d_%H%M%S)"
+JOB_FILE="$DROP_ROOT/${STAMP}_${JOB_KIND}.job"
+
+mkdir -p "$DROP_ROOT"
+
+case "$JOB_KIND" in
+  audio)
+    cmd='cd /app && SCAN_ROOTS="${AUDIO_ROOT:-/nas/S/audio},${TRANSCRIPT_ROOT:-/nas/fileserver/audio/transcriptions}" /usr/bin/env bash run_ingest_all.sh'
+    ;;
+  dashcam)
+    cmd='cd /app && SCAN_ROOTS="${DASHCAM_ROOT:-/nas/fileserver/dashcam},${DASHCAM_ROOT:-/nas/fileserver/dashcam}/transcriptions" DASHCAM_ROOT="${DASHCAM_ROOT:-/nas/fileserver/dashcam}" /usr/bin/env bash run_ingest_all.sh'
+    ;;
+  bodycam)
+    cmd='cd /app && SCAN_ROOTS="${BODYCAM_ROOT:-/nas/fileserver/bodycam}" /usr/bin/env bash run_ingest_all.sh'
+    ;;
+  all)
+    cmd='cd /app && /usr/bin/env bash run_ingest_all.sh'
+    ;;
+  *)
+    echo "Usage: $0 {audio|dashcam|bodycam|all}" >&2
+    exit 2
+    ;;
+esac
+
+cat > "$JOB_FILE" <<JOB
+#!/usr/bin/env bash
+set -euo pipefail
+$cmd
+JOB
+chmod +x "$JOB_FILE"
+echo "Created job: $JOB_FILE"

--- a/deploy/cron/content_generation.crontab
+++ b/deploy/cron/content_generation.crontab
@@ -1,0 +1,2 @@
+# Run content workflow batch every 30 minutes
+*/30 * * * * cd /app && /usr/local/bin/content-os status >> /var/log/cron-content.log 2>&1

--- a/deploy/cron/ingest.crontab
+++ b/deploy/cron/ingest.crontab
@@ -1,0 +1,2 @@
+# Sync legacy drop from deathstar, then run ingest every 5 minutes
+*/5 * * * * cd /app && /usr/bin/env bash deploy/sync_from_legacy_drop.sh >> /var/log/cron-sync.log 2>&1 && /usr/bin/env bash run_ingest_all.sh >> /var/log/cron-ingest.log 2>&1

--- a/deploy/path_profiles.env.example
+++ b/deploy/path_profiles.env.example
@@ -1,0 +1,36 @@
+# Copy this file to .env and customize per host.
+#
+# Endpoint map:
+# - S drive target (preferred long-term audio store)
+# - NAS1 legacy filesystem
+# - NAS share mounted by deathstar-xps (/media/scott/NAS)
+
+# Host path mounted into containers at /nas
+NAS_ROOT=/media/scott/NAS
+
+# Shared queue for distributed workers
+DROP_ROOT=/nas/drop
+
+# Preferred roots by data family
+AUDIO_ROOT=/nas/S/audio
+DASHCAM_ROOT=/nas/fileserver/dashcam
+BODYCAM_ROOT=/nas/fileserver/bodycam
+TRANSCRIPT_ROOT=/nas/fileserver/audio/transcriptions
+LEGACY_ROOT=/nas/fileserver
+
+# Scanner roots consumed by run_ingest_all.sh / ingest_transcriptsv5_3.py
+SCAN_ROOTS=/nas/S/audio,/nas/fileserver/audio,/nas/fileserver/audio/transcriptions,/nas/fileserver/bodycam,/nas/fileserver/dashcam,/nas/fileserver/dashcam/transcriptions
+
+# Neo4j (migrated DB endpoint)
+NEO4J_URI=bolt://neo4j-host:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=change-me
+NEO4J_DB=neo4j
+
+# Legacy deathstar drop path visible on x1-370
+LEGACY_DROP_ROOT=/nas/fileserver/incoming/deathstar
+YOLO_ROOT=/nas/fileserver/dashcam/yolo
+META_ROOT=/nas/fileserver/dashcam/metadata
+
+# Canonical NAS1 root on x1-370
+CANONICAL_ROOT=/nas/fileserver

--- a/deploy/start-cron.sh
+++ b/deploy/start-cron.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CRON_FILE="${CRON_FILE:-/app/deploy/cron/ingest.crontab}"
+
+if [[ ! -f "$CRON_FILE" ]]; then
+  echo "Cron file not found: $CRON_FILE" >&2
+  exit 1
+fi
+
+cp "$CRON_FILE" /etc/cron.d/app-cron
+chmod 0644 /etc/cron.d/app-cron
+crontab /etc/cron.d/app-cron
+
+mkdir -p /var/log
+touch /var/log/cron.log
+
+exec cron -f

--- a/deploy/sync_from_legacy_drop.sh
+++ b/deploy/sync_from_legacy_drop.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sync files dropped by legacy host (deathstar-xps) into canonical roots on x1-370.
+# Safe for repeated runs; uses rsync --ignore-existing by default.
+
+LEGACY_DROP_ROOT="${LEGACY_DROP_ROOT:-/nas/fileserver/incoming/deathstar}"
+AUDIO_ROOT="${AUDIO_ROOT:-/nas/fileserver/audio}"
+DASHCAM_ROOT="${DASHCAM_ROOT:-/nas/fileserver/dashcam}"
+BODYCAM_ROOT="${BODYCAM_ROOT:-/nas/fileserver/bodycam}"
+TRANSCRIPT_ROOT="${TRANSCRIPT_ROOT:-/nas/fileserver/audio/transcriptions}"
+YOLO_ROOT="${YOLO_ROOT:-/nas/fileserver/dashcam/yolo}"
+META_ROOT="${META_ROOT:-/nas/fileserver/dashcam/metadata}"
+
+RSYNC_FLAGS=${RSYNC_FLAGS:---archive --human-readable --ignore-existing}
+
+mkdir -p "$AUDIO_ROOT" "$DASHCAM_ROOT" "$BODYCAM_ROOT" "$TRANSCRIPT_ROOT" "$YOLO_ROOT" "$META_ROOT"
+
+if [[ ! -d "$LEGACY_DROP_ROOT" ]]; then
+  echo "Legacy drop root not found: $LEGACY_DROP_ROOT" >&2
+  exit 2
+fi
+
+sync_dir() {
+  local src="$1"
+  local dst="$2"
+  if [[ -d "$src" ]]; then
+    echo "Syncing $src -> $dst"
+    rsync $RSYNC_FLAGS "$src/" "$dst/"
+  fi
+}
+
+# Expected optional folder layout from legacy host drop:
+# incoming/deathstar/{audio,dashcam,bodycam,transcripts,yolo,metadata}
+sync_dir "$LEGACY_DROP_ROOT/audio" "$AUDIO_ROOT"
+sync_dir "$LEGACY_DROP_ROOT/dashcam" "$DASHCAM_ROOT"
+sync_dir "$LEGACY_DROP_ROOT/bodycam" "$BODYCAM_ROOT"
+sync_dir "$LEGACY_DROP_ROOT/transcripts" "$TRANSCRIPT_ROOT"
+sync_dir "$LEGACY_DROP_ROOT/yolo" "$YOLO_ROOT"
+sync_dir "$LEGACY_DROP_ROOT/metadata" "$META_ROOT"
+
+# Also copy flat sidecars from drop root by extension when present.
+for ext in srt vtt txt json csv; do
+  find "$LEGACY_DROP_ROOT" -maxdepth 2 -type f -name "*.${ext}" -print0 \
+    | xargs -0 -I{} rsync $RSYNC_FLAGS "{}" "$TRANSCRIPT_ROOT/" || true
+done
+
+echo "Legacy drop sync complete."

--- a/deploy/worker_ingest.sh
+++ b/deploy/worker_ingest.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DROP_ROOT="${DROP_ROOT:-/nas/drop}"
+CLAIMED_DIR="${CLAIMED_DIR:-$DROP_ROOT/claimed}"
+DONE_DIR="${DONE_DIR:-$DROP_ROOT/done}"
+FAILED_DIR="${FAILED_DIR:-$DROP_ROOT/failed}"
+PATTERN="${PATTERN:-*.job}"
+
+mkdir -p "$DROP_ROOT" "$CLAIMED_DIR" "$DONE_DIR" "$FAILED_DIR"
+
+shopt -s nullglob
+jobs=("$DROP_ROOT"/$PATTERN)
+if (( ${#jobs[@]} == 0 )); then
+  echo "No job files found in $DROP_ROOT"
+  exit 0
+fi
+
+host="$(hostname)"
+for job in "${jobs[@]}"; do
+  base="$(basename "$job")"
+  claim="$CLAIMED_DIR/${base}.${host}.$$"
+
+  if ! mv "$job" "$claim" 2>/dev/null; then
+    continue
+  fi
+
+  echo "Claimed job: $claim"
+
+  if bash "$claim"; then
+    mv "$claim" "$DONE_DIR/${base}.done"
+    echo "Completed job: $base"
+  else
+    mv "$claim" "$FAILED_DIR/${base}.failed"
+    echo "Failed job: $base" >&2
+  fi
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,82 @@
+services:
+  ingest-service:
+    build: .
+    image: auto-ingest:latest
+    container_name: auto-ingest-service
+    command: ["run_ingest_all.sh"]
+    restart: unless-stopped
+    environment:
+      SCAN_ROOTS: ${SCAN_ROOTS:-/nas/S/audio,/nas/fileserver/audio,/nas/fileserver/audio/transcriptions,/nas/fileserver/bodycam,/nas/fileserver/dashcam,/nas/fileserver/dashcam/transcriptions}
+      DASHCAM_ROOT: ${DASHCAM_ROOT:-/nas/fileserver/dashcam}
+    volumes:
+      - ./:/app
+      - ${NAS_ROOT:-/media/scott/NAS1}:/nas
+
+  ingest-worker:
+    build: .
+    image: auto-ingest:latest
+    container_name: auto-ingest-worker
+    command: ["deploy/worker_ingest.sh"]
+    restart: unless-stopped
+    environment:
+      DROP_ROOT: ${DROP_ROOT:-/nas/drop}
+      AUDIO_ROOT: ${AUDIO_ROOT:-/nas/S/audio}
+      DASHCAM_ROOT: ${DASHCAM_ROOT:-/nas/fileserver/dashcam}
+      BODYCAM_ROOT: ${BODYCAM_ROOT:-/nas/fileserver/bodycam}
+      TRANSCRIPT_ROOT: ${TRANSCRIPT_ROOT:-/nas/fileserver/audio/transcriptions}
+    volumes:
+      - ./:/app
+      - ${NAS_ROOT:-/media/scott/NAS1}:/nas
+
+
+  sync-service:
+    build: .
+    image: auto-ingest:latest
+    container_name: auto-sync-service
+    command: ["deploy/sync_from_legacy_drop.sh"]
+    restart: unless-stopped
+    environment:
+      LEGACY_DROP_ROOT: ${LEGACY_DROP_ROOT:-/nas/fileserver/incoming/deathstar}
+      AUDIO_ROOT: ${AUDIO_ROOT:-/nas/fileserver/audio}
+      DASHCAM_ROOT: ${DASHCAM_ROOT:-/nas/fileserver/dashcam}
+      BODYCAM_ROOT: ${BODYCAM_ROOT:-/nas/fileserver/bodycam}
+      TRANSCRIPT_ROOT: ${TRANSCRIPT_ROOT:-/nas/fileserver/audio/transcriptions}
+      YOLO_ROOT: ${YOLO_ROOT:-/nas/fileserver/dashcam/yolo}
+      META_ROOT: ${META_ROOT:-/nas/fileserver/dashcam/metadata}
+    volumes:
+      - ./:/app
+      - ${NAS_ROOT:-/media/scott/NAS1}:/nas
+
+  content-service:
+    build: .
+    image: auto-ingest:latest
+    container_name: content-generation-service
+    command: ["-m", "content_os", "status"]
+    restart: unless-stopped
+    volumes:
+      - ./:/app
+
+  ingest-cron:
+    build: .
+    image: auto-ingest:latest
+    container_name: ingest-cron
+    entrypoint: ["/app/deploy/start-cron.sh"]
+    environment:
+      CRON_FILE: /app/deploy/cron/ingest.crontab
+      SCAN_ROOTS: ${SCAN_ROOTS:-/nas/S/audio,/nas/fileserver/audio,/nas/fileserver/audio/transcriptions,/nas/fileserver/bodycam,/nas/fileserver/dashcam,/nas/fileserver/dashcam/transcriptions}
+      DASHCAM_ROOT: ${DASHCAM_ROOT:-/nas/fileserver/dashcam}
+    restart: unless-stopped
+    volumes:
+      - ./:/app
+      - ${NAS_ROOT:-/media/scott/NAS1}:/nas
+
+  content-cron:
+    build: .
+    image: auto-ingest:latest
+    container_name: content-cron
+    entrypoint: ["/app/deploy/start-cron.sh"]
+    environment:
+      CRON_FILE: /app/deploy/cron/content_generation.crontab
+    restart: unless-stopped
+    volumes:
+      - ./:/app

--- a/docs/deployment_runbook.md
+++ b/docs/deployment_runbook.md
@@ -1,0 +1,235 @@
+# Auto-Ingest Deployment Runbook
+
+This guide explains **what each deployment file does**, how to configure it, and how to run the services reliably across hosts.
+
+## 1) File-by-file operational guide
+
+### `Dockerfile`
+Purpose:
+- Builds a reusable runtime image for ingestion scripts and Content OS CLI workflows.
+
+How it works:
+1. Uses `python:3.11-slim`.
+2. Installs OS-level runtime packages (`cron`, `tzdata`, certs).
+3. Installs project package + requirements.
+4. Defaults to `python -m content_os --help`.
+
+Operator actions:
+- Rebuild after Python dependency or script changes:
+  ```bash
+  docker compose build --no-cache
+  ```
+
+---
+
+### `docker-compose.yml`
+Purpose:
+- Defines service topology for long-running and scheduled ingestion/content workers.
+
+Services:
+- `ingest-service`: runs `run_ingest_all.sh` directly.
+- `ingest-worker`: claims and executes queued `.job` files from NAS drop.
+- `content-service`: runs Content OS CLI.
+- `ingest-cron`: cron-driven ingest trigger.
+- `content-cron`: cron-driven content trigger.
+
+Operator actions:
+- Start all:
+  ```bash
+  docker compose up -d
+  ```
+- Start only distributed ingest workers:
+  ```bash
+  docker compose up -d ingest-worker ingest-cron
+  ```
+- View live logs:
+  ```bash
+  docker compose logs -f ingest-worker ingest-cron
+  ```
+
+---
+
+### `deploy/path_profiles.env.example`
+Purpose:
+- Template for host-specific path and Neo4j config.
+
+Operator actions:
+1. Copy to `.env`:
+   ```bash
+   cp deploy/path_profiles.env.example .env
+   ```
+2. Edit for host reality:
+   - `NAS_ROOT`
+   - `AUDIO_ROOT` (S drive target)
+   - `DASHCAM_ROOT` / `BODYCAM_ROOT`
+   - `NEO4J_URI`, credentials
+3. Validate env interpolation:
+   ```bash
+   docker compose config
+   ```
+
+---
+
+### `deploy/worker_ingest.sh`
+Purpose:
+- Distributed worker claim loop for NAS queue jobs.
+
+How it works:
+1. Scans `${DROP_ROOT}` for `*.job`.
+2. Atomically `mv` claims to `claimed/`.
+3. Executes claimed script.
+4. Moves completed jobs to `done/`; failures to `failed/`.
+
+Operator actions:
+- Confirm worker queue paths exist and are shared across hosts.
+- Ensure `.job` payloads are executable scripts with `set -euo pipefail`.
+
+---
+
+### `deploy/sync_from_legacy_drop.sh`
+Purpose:
+- Moves/copies legacy drop content from deathstar into canonical x1-370 roots before ingest.
+
+How it works:
+1. Reads `LEGACY_DROP_ROOT` (default `/nas/fileserver/incoming/deathstar`).
+2. Rsyncs folders (`audio`, `dashcam`, `bodycam`, `transcripts`, `yolo`, `metadata`).
+3. Copies sidecar transcript/metadata file types (`.srt`, `.vtt`, `.txt`, `.json`, `.csv`).
+
+Operator actions:
+- Ensure SMB/NAS path from deathstar is mounted on x1-370 under NAS1.
+- Run standalone for verification:
+  ```bash
+  docker compose run --rm sync-service
+  ```
+
+---
+
+### `deploy/create_job.sh`
+Purpose:
+- Helper to enqueue jobs by data type (`audio`, `dashcam`, `bodycam`, `all`).
+
+Operator actions:
+- Create jobs:
+  ```bash
+  ./deploy/create_job.sh audio
+  ./deploy/create_job.sh dashcam
+  ./deploy/create_job.sh bodycam
+  ./deploy/create_job.sh all
+  ```
+- Verify queue:
+  ```bash
+  ls -lah /nas/drop/*.job
+  ```
+
+---
+
+### `deploy/start-cron.sh`
+Purpose:
+- Installs selected crontab and runs cron foreground in container.
+
+Operator actions:
+- Swap cron schedule by setting `CRON_FILE` in compose service.
+- Recreate cron service after cron file edits:
+  ```bash
+  docker compose up -d --force-recreate ingest-cron content-cron
+  ```
+
+---
+
+### `deploy/cron/ingest.crontab`
+Purpose:
+- Ingest schedule trigger.
+
+Current behavior:
+- Runs every 5 minutes.
+
+Operator actions:
+- Tune cadence by editing cron expression.
+- Keep script lock behavior enabled in `run_ingest_all.sh`.
+
+---
+
+### `deploy/cron/content_generation.crontab`
+Purpose:
+- Content workflow schedule trigger.
+
+Current behavior:
+- Runs every 30 minutes.
+
+Operator actions:
+- Adjust cadence based on publishing and review workload.
+
+---
+
+### `README.md`
+Purpose:
+- High-level project and deployment overview.
+
+Operator actions:
+- Treat `README.md` as entry-point summary.
+- Use this runbook for detailed execution + operations.
+
+## 2) Standard deployment procedure
+
+1. Configure host env:
+   ```bash
+   cp deploy/path_profiles.env.example .env
+   # edit .env
+   ```
+2. Build image:
+   ```bash
+   docker compose build
+   ```
+3. Start services:
+   ```bash
+   docker compose up -d sync-service ingest-service ingest-worker content-service ingest-cron content-cron
+   ```
+4. Verify:
+   ```bash
+   docker compose ps
+   docker compose logs --tail=100 ingest-service ingest-worker ingest-cron
+   ```
+
+## 3) Multi-host distributed rollout
+
+On each worker host:
+1. Mount the same NAS share path used by `NAS_ROOT`.
+2. Sync repo and `.env`.
+3. Start at least `ingest-worker`.
+
+Dispatcher host:
+1. Generate jobs with `deploy/create_job.sh`.
+2. Monitor `drop/claimed`, `drop/done`, `drop/failed`.
+
+## 4) Operational checks and troubleshooting
+
+### Health checks
+- Containers running:
+  ```bash
+  docker compose ps
+  ```
+- Queue movement:
+  ```bash
+  ls -lah /nas/drop /nas/drop/claimed /nas/drop/done /nas/drop/failed
+  ```
+- Cron output:
+  ```bash
+  docker compose exec ingest-cron tail -n 200 /var/log/cron-ingest.log
+  docker compose exec content-cron tail -n 200 /var/log/cron-content.log
+  ```
+
+### Common issues
+1. **No jobs processed**
+   - Check `${DROP_ROOT}` mapping and permissions.
+2. **Duplicate work risk**
+   - Ensure job claim path is same shared NAS and `mv` is atomic on that filesystem.
+3. **Neo4j connection failures**
+   - Verify `.env` endpoint and credentials after DB migration.
+4. **Missing input files**
+   - Reconcile path map between S-drive migration and NAS1 legacy roots.
+
+## 5) Change management recommendations
+
+- Treat `.env` as host profile; keep a versioned `.env.example` only.
+- Change one schedule at a time and observe queue pressure for 24h.
+- Keep ingestion and content services independent so one pipeline cannot starve the other.


### PR DESCRIPTION
### Motivation
- Provide a reproducible container runtime and service topology to run ingestion and Content OS workflows in long-running, cron-driven, and distributed worker modes.
- Enable safe multi-host collaboration by adding a NAS drop queue pattern and a sync helper to migrate legacy host drops into canonical processing roots.

### Description
- Add a `Dockerfile` that builds a `python:3.11-slim` image with `cron`, timezone data, and installs the project package so the container can run the Content OS CLI.
- Add `docker-compose.yml` defining `ingest-service`, `ingest-worker`, `sync-service`, `content-service`, and cron services with appropriate mounts and environment interpolation.
- Add deploy helpers and orchestration scripts: `deploy/create_job.sh`, `deploy/worker_ingest.sh`, `deploy/sync_from_legacy_drop.sh`, `deploy/start-cron.sh`, and cron schedules under `deploy/cron/`, plus `deploy/path_profiles.env.example` for host configuration.
- Add operational documentation and runbook files including `docs/deployment_runbook.md` and expanded `README.md` sections describing containerization, scheduling, and distributed worker patterns.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc248ea348325ab8028d846280f28)